### PR TITLE
Unicode support for psycopg2 native hstore implementation

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/psycopg2.py
+++ b/lib/sqlalchemy/dialects/postgresql/psycopg2.py
@@ -393,7 +393,8 @@ class PGDialect_psycopg2(PGDialect):
                 hstore_oids = self._hstore_oids(conn)
                 if hstore_oids is not None:
                     oid, array_oid = hstore_oids
-                    extras.register_hstore(conn, oid=oid, array_oid=array_oid)
+                    extras.register_hstore(conn, oid=oid, array_oid=array_oid,
+                                           unicode=True)
             fns.append(on_connect)
 
         if fns:


### PR DESCRIPTION
This is draft pull request for unicode support for psycopg2 native hstore implementation. You would probably expect unittests for this and may be unicode support for non-native hstore support. Please, point this out and I will fix pull request.

I will also add some comments about unclear points in the source code.
