### PR TITLE
Fix bug when prop.composite_class exists but not a class

### DIFF
--- a/lib/sqlalchemy/ext/mutable.py
+++ b/lib/sqlalchemy/ext/mutable.py
@@ -591,7 +591,7 @@ def _setup_composite_listener():
     import types
     def _listen_for_type(mapper, class_):
         for prop in mapper.iterate_properties:
-            if (hasattr(prop, 'composite_class') and (type(prop.composite_class) is types.ClassType) and
+            if (hasattr(prop, 'composite_class') and (type(prop.composite_class) in (types.ClassType, types.TypeType)) and
                 issubclass(prop.composite_class, MutableComposite)):
                 prop.composite_class._listen_on_attribute(
                     getattr(class_, prop.key), False, class_)


### PR DESCRIPTION
Check if prop.compostite_class is of class type before checking if it is a subclass of `MutableComposite`.
