### PR TITLE
#2628: types.Variant() has a __repr__ usable by Alembic

### DIFF
--- a/lib/sqlalchemy/dialects/drizzle/base.py
+++ b/lib/sqlalchemy/dialects/drizzle/base.py
@@ -263,6 +263,13 @@ class CHAR(_StringType, sqltypes.CHAR):
 class ENUM(mysql_dialect.ENUM):
     """Drizzle ENUM type."""
 
+    __kwargs_signature__ = (
+        ('strict', False),
+        ('collation', None),
+        ('binary', False),
+        ('quoting', 'unquoted'),
+    )
+
     def __init__(self, *enums, **kw):
         """Construct an ENUM.
 

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -977,6 +977,15 @@ class ENUM(sqltypes.Enum, _StringType):
     """MySQL ENUM type."""
 
     __visit_name__ = 'ENUM'
+    __kwargs_signature__ = (
+        ('strict', False),
+        ('charset', None),
+        ('collation', None),
+        ('ascii', False),
+        ('unicode', False),
+        ('binary', False),
+        ('quoting', 'unquoted'),
+    )
 
     def __init__(self, *enums, **kw):
         """Construct an ENUM.

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -763,6 +763,10 @@ class ENUM(sqltypes.Enum):
 
     """
 
+    __kwargs_signature__ = (
+        ('create_type', True),
+    )
+
     def __init__(self, *enums, **kw):
         """Construct an :class:`~.postgresql.ENUM`.
 

--- a/test/sql/test_types.py
+++ b/test/sql/test_types.py
@@ -655,6 +655,35 @@ class VariantTest(fixtures.TestBase, AssertsCompiledSQL):
             'fooUTWO'
         )
 
+    def test_repr(self):
+        test_objects = (
+            (types.String().with_variant(
+                dialects.mysql.VARCHAR(32, collation='foo', ascii=True), 
+                'mysql'),
+            "VARCHAR(collation='foo', ascii=True)"),
+            (types.Enum('red', 'green', 'blue').with_variant(
+                dialects.postgresql.ENUM(
+                    'red', 'green', 'blue', name="rgb_enum", create_type=False),
+                'postgresql'),
+            "ENUM('red', 'green', 'blue', create_type=False, convert_unicode="
+            "False, name='rgb_enum', inherit_schema=False)"),
+            (types.Enum('red', 'green', 'blue').with_variant(
+                dialects.drizzle.ENUM('red', 'green', 'blue', unicode=True), 
+                'drizzle'),
+            "ENUM('red', 'green', 'blue', unicode=True)"),
+            (types.Integer().with_variant(
+                dialects.mssql.TINYINT(), 
+                'mssql'),
+            "TINYINT()"),
+            (types.Numeric().with_variant(
+                dialects.oracle.NUMBER(precision='10', scale='4'), 
+                'oracle'),
+            "NUMBER(precision='10', scale='4')")
+        )
+        for obj, result in test_objects:
+            eq_(repr(obj), result)
+
+
 class UnicodeTest(fixtures.TestBase):
     """Exercise the Unicode and related types.
 


### PR DESCRIPTION
This pull request is meant to fix [Trac ticket #2628](http://www.sqlalchemy.org/trac/ticket/2628) 'need a working **repr** for Variant".

Note that generic_repr() now builds kwargs into the repr by looking for a **kwargs_signature** attribute in the to_inspect object. This complements inspect.getargspec() in building the list of all arguments and whether they are non-default. So any type that accepts kwargs will need to define this attribute in order to have a comprehensive repr. That's something to keep up to date in the future, but the only alternative I saw was to refactor any type using an _arg or *_kwargs into named arguments, which meant backwards-incompatibility for those Enums at the least.

Please see the tests in test_repr().
