### PR TITLE
Fix unicode literals on Python 3.1 and 3.2

### DIFF
--- a/lib/sqlalchemy/testing/suite/test_select.py
+++ b/lib/sqlalchemy/testing/suite/test_select.py
@@ -1,6 +1,7 @@
 from .. import fixtures, config
 from ..assertions import eq_
 
+from sqlalchemy import util
 from sqlalchemy import Integer, String, select, func
 
 from ..schema import Table, Column
@@ -63,7 +64,7 @@ class OrderByLabelTest(fixtures.TablesTest):
         ly = (func.lower(table.c.q) + table.c.p).label('ly')
         self._assert_result(
             select([lx, ly]).order_by(lx, ly.desc()),
-            [(3, u'q1p3'), (5, u'q2p2'), (7, u'q3p1')]
+            [(3, util.u('q1p3')), (5, util.u('q2p2')), (7, util.u('q3p1'))]
         )
 
     def test_plain_desc(self):

--- a/test/dialect/test_postgresql.py
+++ b/test/dialect/test_postgresql.py
@@ -3265,17 +3265,17 @@ class HStoreRoundTripTest(fixtures.TablesTest):
 
     def _test_unicode_round_trip(self, engine):
         s = select([
-                hstore(
-                    array([u'réveillé', u'drôle', u'S’il']),
-                    array([u'réveillé', u'drôle', u'S’il'])
-                )
-            ])
+            hstore(
+                array([util.u('réveillé'), util.u('drôle'), util.u('S’il')]),
+                array([util.u('réveillé'), util.u('drôle'), util.u('S’il')])
+            )
+        ])
         eq_(
             engine.scalar(s),
             {
-                u'réveillé': u'réveillé',
-                u'drôle': u'drôle',
-                u'S’il': u'S’il'
+                util.u('réveillé'): util.u('réveillé'),
+                util.u('drôle'): util.u('drôle'),
+                util.u('S’il'): util.u('S’il')
             }
         )
 


### PR DESCRIPTION
A few tests use u'' unicode literals which are not
supported in Python versions 3.1 and 3.2.
