### PR TITLE
Add getitem operator to OPERATORS for postgres ARRAY

### DIFF
--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -115,6 +115,7 @@ OPERATORS = {
     operators.asc_op: ' ASC',
     operators.nullsfirst_op: ' NULLS FIRST',
     operators.nullslast_op: ' NULLS LAST',
+    operators.getitem: ''
 }
 
 FUNCTIONS = {


### PR DESCRIPTION
Hi.
I have the exception when without this path using sqlalchemy and postgres.
When I try to sort and limit query by an item of ARRAY field result is the exception:

in visit_binary
    OPERATORS[operator], **kw)
KeyError: <built-in function getitem>

for example:

session.query(Product).filter(SomeModel.array_field[2] > 500).order_by(SomeModel.array_field[3]).limit(60)
but all ok without limit.
This commit are solved this problem. 
Good luck.
Alexey Terentev
