### PR TITLE
Added checks for maximum column size for MSSQL text types

### DIFF
--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -530,13 +530,10 @@ class MSTypeCompiler(compiler.GenericTypeCompiler):
         return self.visit_NTEXT(type_)
 
     def visit_NTEXT(self, type_):
-        type_.length = None
         return self._extend("NTEXT", type_)
 
     def visit_TEXT(self, type_):
-        type_.length = None
         return self._extend("TEXT", type_)
-
 
     def visit_VARCHAR(self, type_):
         length = type_.length

--- a/test/dialect/mssql/test_types.py
+++ b/test/dialect/mssql/test_types.py
@@ -153,20 +153,11 @@ class TypeDDLTest(fixtures.TestBase):
             (mssql.MSText, [], {'collation': 'Latin1_General_CI_AS'},
              'TEXT COLLATE Latin1_General_CI_AS'),
 
-            (mssql.MSText, [10000], {},
-             'TEXT'),
-            (mssql.MSText, [10000], {'collation': 'Latin1_General_CI_AS'},
-             'TEXT COLLATE Latin1_General_CI_AS'),
-
             (mssql.MSNText, [], {},
              'NTEXT'),
             (mssql.MSNText, [], {'collation': 'Latin1_General_CI_AS'},
              'NTEXT COLLATE Latin1_General_CI_AS'),
 
-            (mssql.MSNText, [10000], {},
-             'NTEXT'),
-            (mssql.MSNText, [10000], {'collation': 'Latin1_General_CI_AS'},
-             'NTEXT COLLATE Latin1_General_CI_AS'),
            ]
 
         metadata = MetaData()


### PR DESCRIPTION
Hi,

I have updated the mssql dialect slightly to avoid generating text fields which are too large for MS SQL columns when creating tables. I have also prevented passing in lengths to text types, as this will also cause errors.
