### PR TITLE
mapping multiple tables for one class

### DIFF
--- a/lib/sqlalchemy/orm/persistence.py
+++ b/lib/sqlalchemy/orm/persistence.py
@@ -525,7 +525,7 @@ def _emit_insert_statements(base_mapper, uowtransaction,
     """Emit INSERT statements corresponding to value lists collected
     by _collect_insert_commands()."""
 
-    statement = base_mapper._memo(('insert', table), table.insert)
+    statement = base_mapper._memo(('insert', table, table.name), table.insert)
 
     for (connection, pkeys, hasvalue, has_all_pks), \
         records in groupby(insert,


### PR DESCRIPTION
I'm doing something to finish the horizontal shard job.
The examle is sharding to multiple database . And i just do it for
multipls tables in one database.

there is many tables just like  msg_00,msg_01..... msg_99
defind  the class like  Msg()  map the tables .
# 

``` python
m = Msg
number = int(uid)%100
tablename = 'msg_%02d'%(number)
m.__uuid__ = uid
m.__table__.name = tablename
```
# 

now  "m" mapping the table msg_xx .
It works in the select sql.
but fail in the session.add(newmessage) because the sqlalchemy has cache
connection .  event one table is  Table(msg_00) and another is Table
(msg_01)

So, i edit the memo key .   then there is diff  insert object .

---

It's simple change and useful. It‘s safe for the old version .
sorry for my poor english.
