### PR TITLE
re.match to re.search

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -1543,7 +1543,7 @@ class PGDialect(default.DefaultDialect):
 
     def _get_server_version_info(self, connection):
         v = connection.execute("select version()").scalar()
-        m = re.match(
+        m = re.search(
             '(?:PostgreSQL|EnterpriseDB) '
             '(\d+)\.(\d+)(?:\.(\d+))?(?:\.\d+)?(?:devel)?',
             v)


### PR DESCRIPTION
Convert to re.search to eliminate the restriction on only matching the
beginning of the string. This fixes the RE not being able to parse out the differing version string that VMware's Postgres SQL presents.
