### PR TITLE
Added __len__ to AppenderQuery/AppenderMixin.

### DIFF
--- a/lib/sqlalchemy/orm/dynamic.py
+++ b/lib/sqlalchemy/orm/dynamic.py
@@ -249,6 +249,9 @@ class AppenderMixin(object):
         else:
             return self._clone(sess).__getitem__(index)
 
+    def __len__(self):
+        return self.count()
+
     def count(self):
         sess = self.session
         if sess is None:

--- a/test/orm/test_dynamic.py
+++ b/test/orm/test_dynamic.py
@@ -169,6 +169,12 @@ class DynamicTest(_DynamicFixture, _fixtures.FixtureTest, AssertsCompiledSQL):
         u = sess.query(User).first()
         eq_(u.addresses.count(), 1)
 
+    def test_len(self):
+        User, Address = self._user_address_fixture()
+        sess = create_session()
+        u = sess.query(User).first()
+        eq_(len(u.addresses), 1)
+
     def test_dynamic_on_backref(self):
         users, Address, addresses, User = (self.tables.users,
                                 self.classes.Address,


### PR DESCRIPTION
The main motivator for this is consistency in how relationships are handled. If I have backrefs that use len() and I then configure that backref to `lazy='dynamic'`, code breaks.

I realize using `len()` in the first place isn't the best idea in most situations, but its intent is to minimize differences in the behaviour of `lazy='dynamic'`. I hope it's not too heretical.
