### PR TITLE
#2841: MySQL doesn't support MATCH, INITIALLY, or DEFERRED

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -1451,6 +1451,20 @@ class MySQLCompiler(compiler.SQLCompiler):
 class MySQLDDLCompiler(compiler.DDLCompiler):
     def create_table_constraints(self, table):
         """Get table constraints."""
+
+        # For foreign keys, MySQL silently fails or drops other FK attributes
+        # if MATCH, DEFERRABLE, or INITIALLY are defined. So let's raise an
+        # error here.
+        # https://dev.mysql.com/doc/refman/5.5/en/create-table-foreign-keys.html
+        for attr in ('match', 'deferrable', 'initially'):
+            for fk in table.foreign_keys:
+                if getattr(fk, attr) is not None:
+                    raise exc.CompileError(
+                        "MySQL does not support specifying MATCH, DEFERRABLE, "
+                        "or INITIALLY on foreign keys, but a foreign key on "
+                        "table '%s' defines at least one." % table.name
+                    )
+
         constraint_string = super(
                         MySQLDDLCompiler, self).create_table_constraints(table)
 


### PR DESCRIPTION
Implements the raising of a `CompileError` if MySQL is in use and a foreign key uses an option that MySQL does not support. MySQL otherwise fails silently. Trac at http://www.sqlalchemy.org/trac/ticket/2841#ticket.
