### PR TITLE
(0.9) MySQL dialect throws CompileError when unsupported foreign key options are specified, as MySQL silently ignores them [ticket 2841]

### DIFF
--- a/test/engine/test_reflection.py
+++ b/test/engine/test_reflection.py
@@ -638,6 +638,33 @@ class ReflectionTest(fixtures.TestBase, ComparesTables):
                             "a foreign key to target column 'pkg_id'",
                               metadata.create_all)
 
+    @testing.only_on('mysql')
+    def test_fk_attribute_error(self):
+        """
+        MySQL FKs cannot handle certain attributes... throw a CompileError
+        """
+        meta = MetaData(testing.db)
+        Table('users', meta,
+            Column('id', sa.Integer, primary_key=True),
+            Column('name', sa.String(30)),
+            test_needs_fk=True)
+        Table('addresses', meta,
+            Column('id', sa.Integer, primary_key=True),
+            Column('user_id', sa.Integer, sa.ForeignKey(
+                'users.id',
+                name = 'addresses_user_id_fkey',
+                match = 'FULL',
+                onupdate='CASCADE',
+                ondelete='CASCADE'
+            )),
+            test_needs_fk=True)
+
+        assert_raises_message(sa.exc.CompileError,
+            "MySQL does not support specifying MATCH, DEFERRABLE, or "
+            "INITIALLY on foreign keys, but a foreign key on table "
+            "'addresses' defines at least one.",
+            meta.create_all)
+
     def test_composite_pks(self):
         """test reflection of a composite primary key"""
 


### PR DESCRIPTION
0.9 version of ticket 2841:

MySQL dialect raises a CompileError if a foreign key option that MySQL does not support is specified.

http://www.sqlalchemy.org/trac/ticket/2841
