### PR TITLE
Add support for python3.3 list.clear() on orm.collections

### DIFF
--- a/lib/sqlalchemy/orm/collections.py
+++ b/lib/sqlalchemy/orm/collections.py
@@ -1163,7 +1163,6 @@ def _list_decorators():
 
     def clear(fn):
         def clear(self, index=-1):
-            __before_delete(self)
             for item in self:
                 __del(self, item)
             fn(self)

--- a/test/orm/test_collection.py
+++ b/test/orm/test_collection.py
@@ -284,6 +284,16 @@ class CollectionsTest(fixtures.ORMTest):
             del control[:]
             assert_eq()
 
+        if hasattr(direct, 'clear'):
+            for i in range(1, 4):
+                e = creator()
+                direct.append(e)
+                control.append(e)
+
+            direct.clear()
+            control.clear()
+            assert_eq()
+
         if hasattr(direct, 'extend'):
             values = [creator(), creator(), creator()]
 


### PR DESCRIPTION
python 3.3 added a new method "clear()" for lists. So added support for that.
- I am not sure if the "__before_delete" should be called or not. 
- Lack proper unit-tests. If you wish I might give a try a later
