### PR TITLE
Fix sessionmaker.__repr__

### DIFF
--- a/lib/sqlalchemy/orm/session.py
+++ b/lib/sqlalchemy/orm/session.py
@@ -2311,7 +2311,7 @@ class sessionmaker(_SessionClassMethods):
         self.kw.update(new_kw)
 
     def __repr__(self):
-        return "%s(class_=%r%s)" % (
+        return "%s(class_=%r,%s)" % (
                     self.__class__.__name__,
                     self.class_.__name__,
                     ", ".join("%s=%r" % (k, v) for k, v in self.kw.items())


### PR DESCRIPTION
A comma separating `class_` from the other args. It's still there even when kw is empty, which is syntactically correct.
