### PR TITLE
Remove terminated connections from the pool.

### DIFF
--- a/lib/sqlalchemy/dialects/mssql/pymssql.py
+++ b/lib/sqlalchemy/dialects/mssql/pymssql.py
@@ -86,6 +86,7 @@ class MSDialect_pymssql(MSDialect):
     def is_disconnect(self, e, connection, cursor):
         for msg in (
             "Adaptive Server connection timed out",
+            "Net-Lib error during Connection reset by peer",
             "message 20003",  # connection timeout
             "Error 10054",
             "Not connected to any MS SQL server",

--- a/test/dialect/mssql/test_engine.py
+++ b/test/dialect/mssql/test_engine.py
@@ -131,10 +131,11 @@ class ParseConnectTest(fixtures.TestBase):
 
         for error in [
                 'Adaptive Server connection timed out',
+                'Net-Lib error during Connection reset by peer',
                 'message 20003',
-                "Error 10054",
-                "Not connected to any MS SQL server",
-                "Connection is closed"
+                'Error 10054',
+                'Not connected to any MS SQL server',
+                'Connection is closed'
                 ]:
             eq_(dialect.is_disconnect(error, None, None), True)
 


### PR DESCRIPTION
In pymssql, if you terminate a long running query manually
it will give you a connection reset by peer message, but this
connection remains in the pool and will be re-used.
