### PR TITLE
session docs: Change `object` to `someobject`

### DIFF
--- a/doc/build/orm/session.rst
+++ b/doc/build/orm/session.rst
@@ -462,7 +462,7 @@ available on :class:`~sqlalchemy.orm.session.Session`::
 The newer :ref:`core_inspection_toplevel` system can also be used::
 
     from sqlalchemy import inspect
-    session = inspect(object).session
+    session = inspect(someobject).session
 
 .. _session_faq_threadsafe:
 


### PR DESCRIPTION
This makes the code block more consistent with the preceding one and also prevents the variable from being colored as a builtin (which `object` is) during syntax highlighting.
