### PR TITLE
MySQL-Python <1.2.5 unicode compatibility note

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/mysqldb.py
+++ b/lib/sqlalchemy/dialects/mysql/mysqldb.py
@@ -46,6 +46,9 @@ MySQL-python version 1.2.2 has a serious memory leak related
 to unicode conversion, a feature which is disabled via ``use_unicode=0``.
 It is strongly advised to use the latest version of MySQL-Python.
 
+:class:`~sqlalchemy.Unicode` and  :class:`~sqlalchemy.UnicodeText`
+columns will have :class:`str` instead of :class:`unicode` values when
+used with MySQL-python versions prior to 1.2.5.
 """
 
 from .base import (MySQLDialect, MySQLExecutionContext,


### PR DESCRIPTION
Unicode and UnicodeText columns will have `str` instead of `unicode` values when used with MySQL-python versions prior to 1.2.5.

This bug sent me on a 2-hour wild goose chase today. This example demonstrates the issue if you have MySQL-Python 1.2.3 installed: https://gist.github.com/irskep/8345460

Stack Overflow question documenting my confusion: http://stackoverflow.com/questions/21032900/sqlalchemys-unicodetext-column-is-giving-me-a-str-on-my-mysql-table-shouldnt/21034742

I didn't try to build the docs with this change, just used the GitHub editor.

I didn't test with MySQL-Python 1.2.4, so that version might actually work, but people should keep up to date anyway. :-P
