### PR TITLE
expose SchemaVisitor in the compatibility layer

### DIFF
--- a/lib/sqlalchemy/schema.py
+++ b/lib/sqlalchemy/schema.py
@@ -8,6 +8,10 @@
 
 """
 
+from .sql.base import (
+    SchemaVisitor
+    )
+
 
 from .sql.schema import (
     CheckConstraint,


### PR DESCRIPTION
sqlalchemy-migrate uses SchemaVisitor. It was one of the only
objects that changed namespaces without compatibility that we use.

Would love to get this added to remove a work around we need at
https://review.openstack.org/#/c/66156/
