### PR TITLE
Fix TypeError for class_mapper called w/ iterable

### DIFF
--- a/lib/sqlalchemy/orm/base.py
+++ b/lib/sqlalchemy/orm/base.py
@@ -375,7 +375,7 @@ def class_mapper(class_, configure=True):
     if mapper is None:
         if not isinstance(class_, type):
             raise sa_exc.ArgumentError(
-                    "Class object expected, got '%r'." % class_)
+                    "Class object expected, got '%r'." % (class_, ))
         raise exc.UnmappedClassError(class_)
     else:
         return mapper


### PR DESCRIPTION
When the `class_` passed is not a mapped class but is actually an iterable, the string formatting operation fails with a `TypeError: not all arguments converted` exception, and the expected `ArgumentError` is not raised. Calling code which is using reflection and expects this error will fail (e.g. the [sadisplay](https://pypi.python.org/pypi/sadisplay) module).
