### PR TITLE
Remove uneeded import from code example

### DIFF
--- a/lib/sqlalchemy/ext/mutable.py
+++ b/lib/sqlalchemy/ext/mutable.py
@@ -49,7 +49,6 @@ tracks all parents which reference it.  Below, we illustrate the a simple
 version of the :class:`.MutableDict` dictionary object, which applies
 the :class:`.Mutable` mixin to a plain Python dictionary::
 
-    import collections
     from sqlalchemy.ext.mutable import Mutable
 
     class MutableDict(Mutable, dict):


### PR DESCRIPTION
This had me reread the code twice to see if I missed why the import was
present.
