### PR TITLE
expose `binary_type` in `util` module

### DIFF
--- a/lib/sqlalchemy/util/__init__.py
+++ b/lib/sqlalchemy/util/__init__.py
@@ -8,7 +8,7 @@ from .compat import callable, cmp, reduce,  \
     threading, py3k, py33, py2k, py3k_warning, jython, pypy, cpython, win32, \
     set_types, py26, \
     pickle, dottedgetter, parse_qsl, namedtuple, next, WeakSet, reraise, \
-    raise_from_cause, u, b, ue, string_types, text_type, int_types
+    raise_from_cause, u, b, ue, string_types, text_type, int_types, binary_type
 
 from ._collections import KeyedTuple, ImmutableContainer, immutabledict, \
     Properties, OrderedProperties, ImmutableProperties, OrderedDict, \


### PR DESCRIPTION
it is used in [`sql/compiler.py(849)render_literal_value()`](https://github.com/zzzeek/sqlalchemy/blob/rel_0_8/lib/sqlalchemy/sql/compiler.py#L849), causing an `AttributeError`
