### PR TITLE
python_type for ARRAY (PGArray)

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -834,6 +834,10 @@ class ARRAY(sqltypes.Concatenable, sqltypes.TypeEngine):
         self.as_tuple = as_tuple
         self.dimensions = dimensions
 
+    @property
+    def python_type(self):
+        return list
+
     def compare_values(self, x, y):
         return x == y
 


### PR DESCRIPTION
It change help me in use  column.type.python_type. I hope it will help and other developers.
