### PR TITLE
Fix static analysis of scoped_session

### DIFF
--- a/lib/sqlalchemy/orm/scoping.py
+++ b/lib/sqlalchemy/orm/scoping.py
@@ -73,6 +73,8 @@ class scoped_session(object):
     def __getattr__(self, attr):
         if attr in Session.public_methods:
             return getattr(self.registry(), attr)
+        else:
+            raise AttributeError(attr)
 
     def remove(self):
         """Dispose of the current :class:`.Session`, if present.

--- a/lib/sqlalchemy/orm/scoping.py
+++ b/lib/sqlalchemy/orm/scoping.py
@@ -70,6 +70,10 @@ class scoped_session(object):
         else:
             return self.registry()
 
+    def __getattr__(self, attr):
+        if attr in Session.public_methods:
+            return getattr(self.registry(), attr)
+
     def remove(self):
         """Dispose of the current :class:`.Session`, if present.
 
@@ -143,15 +147,6 @@ class scoped_session(object):
 
 ScopedSession = scoped_session
 """Old name for backwards compatibility."""
-
-
-def instrument(name):
-    def do(self, *args, **kwargs):
-        return getattr(self.registry(), name)(*args, **kwargs)
-    return do
-
-for meth in Session.public_methods:
-    setattr(scoped_session, meth, instrument(meth))
 
 
 def makeprop(name):


### PR DESCRIPTION
Not sure why the current code was written this way, but it failed to make pylint "find" scoped_session methods.

Here is a little example, in a virtualenv with sqlalchemy and pylint installed:
```
from sqlalchemy import create_engine, Column, Integer, String
from sqlalchemy.orm import sessionmaker, scoped_session
from sqlalchemy.ext.declarative import declarative_base


Base = declarative_base()


class SomeClass(Base):

    __tablename__ = 'some_table'
    key = Column(Integer, primary_key=True)
    name = Column(String(50))


if __name__ == '__main__':
    engine = create_engine('sqlite:///:memory:', echo=True)
    session_factory = sessionmaker(bind=engine)
    Session = scoped_session(session_factory)
    Session.query(SomeClass).get('random')
```

pylint will return:
```
pylint --report=n --disable=C0111,C0103 test.py
************* Module test
W:  9, 0: Class has no __init__ method (no-init)
R:  9, 0: Too few public methods (0/2) (too-few-public-methods)
E: 20, 4: Instance of 'scoped_session' has no 'query' member (no-member)
```

With this patch applied, the error disappears as expected. Since I use a lot of scoped_session in my code, it is really annoying to get this error and it may hide real errors if I disable it.

Thanks for considering.