### PR TITLE
Fix unique constraints reflection in SQLite

### DIFF
--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -940,7 +940,7 @@ class SQLiteDialect(default.DefaultDialect):
 
         UNIQUE_PATTERN = 'CONSTRAINT (\w+) UNIQUE \(([^\)]+)\)'
         return [
-            {'name': name, 'column_names': [c.strip() for c in cols.split(',')]}
+            {'name': name, 'column_names': [c.strip(' "') for c in cols.split(',')]}
             for name, cols in re.findall(UNIQUE_PATTERN, table_data)
         ]
 

--- a/lib/sqlalchemy/testing/suite/test_reflection.py
+++ b/lib/sqlalchemy/testing/suite/test_reflection.py
@@ -385,6 +385,7 @@ class ComponentReflectionTest(fixtures.TablesTest):
                 {'name': 'unique_a_b_c', 'column_names': ['a', 'b', 'c']},
                 {'name': 'unique_a_c', 'column_names': ['a', 'c']},
                 {'name': 'unique_b_c', 'column_names': ['b', 'c']},
+                {'name': 'unique_asc_key', 'column_names': ['asc', 'key']},
             ],
             key=operator.itemgetter('name')
         )
@@ -394,6 +395,9 @@ class ComponentReflectionTest(fixtures.TablesTest):
             Column('a', sa.String(20)),
             Column('b', sa.String(30)),
             Column('c', sa.Integer),
+            # reserved identifiers
+            Column('asc', sa.String(30)),
+            Column('key', sa.String(30)),
             schema=schema
         )
         for uc in uniques:


### PR DESCRIPTION
Reflection of unique constraints didn't work properly, if reserved
identifiers had been used as column names. In this case column names
would be put in double quotes (e.g. the name of column asc would be
returned as "asc").

This issue is only present in 0.8.4 and not in 0.9.x (looks like this had been fixed in 0.9.x but was not backported to 0.8.x).

The snippet to reproduce:

``` python

import sqlalchemy as sa


eng = sa.create_engine('sqlite://')
meta = sa.MetaData(bind=eng)

table = sa.Table(
    'testtbl', meta,
    sa.Column('id', sa.Integer, primary_key=True),
    sa.Column('asc', sa.Integer),
    sa.Column('key', sa.Integer),
    sa.UniqueConstraint('asc', 'key', name='uniq_asc_key')
)
table.create()


inspector = sa.inspect(eng)
print inspector.get_unique_constraints('testtbl')
```
