### PR TITLE
Fixed bug in sqlite reflections were INTEGER type does not take args

### DIFF
--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -827,6 +827,9 @@ class SQLiteDialect(default.DefaultDialect):
             args = ''
         try:
             coltype = self.ischema_names[coltype]
+            if coltype == INTEGER:
+                # INTEGER type does not take arguments
+                args = ''
             if args is not None:
                 args = re.findall(r'(\d+)', args)
                 coltype = coltype(*[int(a) for a in args])


### PR DESCRIPTION
`INTEGER` type no longer takes arguments so a `TypeError: object() takes no parameters` exception was being raised when doing reflection with a sqlite column type of `int(5)` for example. 

This fix ensures no args are passed when creating a `INTEGER` type.
