### PR TITLE
In SingletonThreadPool, do not cleanup a newly created connection

### DIFF
--- a/lib/sqlalchemy/pool.py
+++ b/lib/sqlalchemy/pool.py
@@ -837,9 +837,10 @@ class SingletonThreadPool(Pool):
             pass
         c = self._create_connection()
         self._conn.current = weakref.ref(c)
-        self._all_conns.add(c)
-        if len(self._all_conns) > self.size:
-            self._cleanup()
+        if c not in self._all_conns:
+            if len(self._all_conns) >= self.size:
+                self._cleanup()
+            self._all_conns.add(c)
         return c
 
 


### PR DESCRIPTION
Since `self._all_conns` is a `set`, insertion order is not preserved, so `self._all_conns.pop()` in `SingletonThreadPool.cleanup()` sometimes closes newly created connections:

```
 819     def _cleanup(self):
 820         while len(self._all_conns) > self.size:
 821             c = self._all_conns.pop()
 822             c.close()
```
