### PR TITLE
Remove tables from metadata when autoload fails

### DIFF
--- a/lib/sqlalchemy/sql/schema.py
+++ b/lib/sqlalchemy/sql/schema.py
@@ -353,7 +353,7 @@ class Table(DialectKWArgs, SchemaItem, TableClause):
                 table.dispatch.after_parent_attach(table, metadata)
                 return table
             except:
-                #metadata._remove_table(name, schema)
+                metadata._remove_table(name, schema)
                 raise
 
 

--- a/test/engine/test_reflection.py
+++ b/test/engine/test_reflection.py
@@ -92,6 +92,7 @@ class ReflectionTest(fixtures.TestBase, ComparesTables):
         meta = MetaData(testing.db)
         assert_raises(sa.exc.NoSuchTableError, Table, 'nonexistent',
                       meta, autoload=True)
+        assert 'nonexistent' not in meta.tables
 
     @testing.provide_metadata
     def test_include_columns(self):


### PR DESCRIPTION
If autoloading of a table fails, don't register it in a metadata
instance. It seems that the original behaviour was accidentally
changed in f6198d9abf453182f4b111e0579a7a4ef1614e79, restore it.

Closes issue #2988
