### PR TITLE
Added missing text_type requirement to TextTest

### DIFF
--- a/lib/sqlalchemy/testing/suite/test_types.py
+++ b/lib/sqlalchemy/testing/suite/test_types.py
@@ -107,6 +107,8 @@ class UnicodeTextTest(_UnicodeFixture, fixtures.TablesTest):
         self._test_empty_strings()
 
 class TextTest(fixtures.TablesTest):
+    __requires__ = 'text_type',
+
     @classmethod
     def define_tables(cls, metadata):
         Table('text_table', metadata,


### PR DESCRIPTION
This fixes unnecessary test failures with the exasol dialect
