### PR TITLE
Fix a typo in the ForeignKey

### DIFF
--- a/doc/build/orm/tutorial.rst
+++ b/doc/build/orm/tutorial.rst
@@ -1156,7 +1156,7 @@ declarative, we define this table along with its mapped class, ``Address``:
     ...     __tablename__ = 'addresses'
     ...     id = Column(Integer, primary_key=True)
     ...     email_address = Column(String, nullable=False)
-    ...     user_id = Column(Integer, ForeignKey('users.id'))
+    ...     user_id = Column(Integer, ForeignKey('user.id'))
     ...
     ...     user = relationship("User", backref=backref('addresses', order_by=id))
     ...


### PR DESCRIPTION
The table Address has a ForeignKey to the table User. Thus the correct syntax is: `ForeignKey('user.id'))`
