### PR TITLE
Clarify that an instance's "load" event is also called when it is created

### DIFF
--- a/lib/sqlalchemy/orm/events.py
+++ b/lib/sqlalchemy/orm/events.py
@@ -236,8 +236,9 @@ class InstanceEvents(event.Events):
         ``__new__``, and after initial attribute population has
         occurred.
 
-        This typically occurs when the instance is created based on
-        incoming result rows, and is only called once for that
+        This typically occurs when the instance is created, either
+        based on incoming result rows or by adding a new instance
+        object to the database. It is only called once for that
         instance's lifetime.
 
         Note that during a result-row load, this method is called upon


### PR DESCRIPTION
The documentation is ambiguous for this case; "load" is a bit misleading since the object is not actually loaded when it's created. At least not by sqlalchemy.

Fixed-up pull request (tabs replaced by spaces)
