### PR TITLE
Documentation fix-up: "its" vs. "it's"

### DIFF
--- a/doc/build/changelog/changelog_05.rst
+++ b/doc/build/changelog/changelog_05.rst
@@ -1557,7 +1557,7 @@
         :tickets: 
 
       Column with no name (as in declarative) won't raise a
-      NoneType error when it's string output is requsted
+      NoneType error when its string output is requested
       (such as in a stack trace).
 
     .. change::

--- a/doc/build/changelog/changelog_07.rst
+++ b/doc/build/changelog/changelog_07.rst
@@ -4084,7 +4084,7 @@
 
       The Column.references() method now returns True
       if it has a foreign key referencing the
-      given column exactly, not just it's parent
+      given column exactly, not just its parent
       table.
 
     .. change::

--- a/doc/build/changelog/migration_05.rst
+++ b/doc/build/changelog/migration_05.rst
@@ -338,7 +338,7 @@ extend the ORM.  Heres a summary:
 * **SessionExtension.** - This is an easy to use extension
   class for session events.  In particular, it provides
   ``before_flush()``, ``after_flush()`` and
-  ``after_flush_postexec()`` methods.  It's usage is
+  ``after_flush_postexec()`` methods.  This usage is
   recommended over ``MapperExtension.before_XXX`` in many
   cases since within ``before_flush()`` you can modify the
   flush plan of the session freely, something which cannot
@@ -545,7 +545,7 @@ Removed
 * **get()/load() cleanup**
 
 
-  The ``load()`` method has been removed.  It's
+  The ``load()`` method has been removed.  Its
   functionality was kind of arbitrary and basically copied
   from Hibernate, where it's also not a particularly
   meaningful method.

--- a/doc/build/changelog/migration_08.rst
+++ b/doc/build/changelog/migration_08.rst
@@ -632,7 +632,7 @@ not really a column, CAST operator, or SQL function that
 really drives what kinds of operations are present, it's the
 *type* of the expression.   The implementation details are
 minimal - only a few extra methods are added to the core
-:class:`.ColumnElement` type so that it consults it's
+:class:`.ColumnElement` type so that it consults its
 :class:`.TypeEngine` object for an optional set of operators.
 New or revised operations can be associated with any type,
 either via subclassing of an existing type, by using

--- a/doc/build/changelog/migration_09.rst
+++ b/doc/build/changelog/migration_09.rst
@@ -1504,7 +1504,7 @@ Label constructs can now render as their name alone in an ORDER BY
 
 For the case where a :class:`.Label` is used in both the columns clause
 as well as the ORDER BY clause of a SELECT, the label will render as
-just it's name in the ORDER BY clause, assuming the underlying dialect
+just its name in the ORDER BY clause, assuming the underlying dialect
 reports support of this feature.
 
 E.g. an example like::

--- a/doc/build/core/pooling.rst
+++ b/doc/build/core/pooling.rst
@@ -127,7 +127,7 @@ within a transparent proxy::
     cursor.execute("select foo")
 
 The purpose of the transparent proxy is to intercept the ``close()`` call,
-such that instead of the DBAPI connection being closed, it's returned to the
+such that instead of the DBAPI connection being closed, it is returned to the
 pool::
 
     # "close" the connection.  Returns
@@ -229,7 +229,7 @@ Disconnect Handling - Pessimistic
 
 At the expense of some extra SQL emitted for each connection checked out from the pool,
 a "ping" operation established by a checkout event handler
-can detect an invalid connection before it's used::
+can detect an invalid connection before it is used::
 
     from sqlalchemy import exc
     from sqlalchemy import event

--- a/doc/build/orm/relationships.rst
+++ b/doc/build/orm/relationships.rst
@@ -1013,7 +1013,7 @@ to just ``city='Boston'``.   When using Declarative, rudimentary SQL functions l
 
 The custom criteria we use in a :paramref:`~.relationship.primaryjoin`
 is generally only significant when SQLAlchemy is rendering SQL in
-order to load or represent this relationship. That is, it's  used in
+order to load or represent this relationship. That is, it's used in
 the SQL statement that's emitted in order to perform a per-attribute
 lazy load, or when a join is constructed at query time, such as via
 :meth:`.Query.join`, or via the eager "joined" or "subquery" styles of

--- a/doc/build/orm/session.rst
+++ b/doc/build/orm/session.rst
@@ -663,8 +663,8 @@ new session. Here's some examples:
   copies of itself that are local to individual :class:`~.Session`
   objects.
 
-  In the caching use case, it's common that the ``load=False`` flag
-  is used to remove the overhead of reconciling the object's state
+  In the caching use case, it's common to use the ``load=False``
+  flag to remove the overhead of reconciling the object's state
   with the database.   There's also a "bulk" version of
   :meth:`~.Session.merge` called :meth:`~.Query.merge_result`
   that was designed to work with cache-extended :class:`.Query`
@@ -1868,7 +1868,7 @@ Using Subtransactions with Autocommit
 A subtransaction indicates usage of the :meth:`.Session.begin` method in conjunction with
 the ``subtransactions=True`` flag.  This produces a non-transactional, delimiting construct that
 allows nesting of calls to :meth:`~.Session.begin` and :meth:`~.Session.commit`.
-It's purpose is to allow the construction of code that can function within a transaction
+Its purpose is to allow the construction of code that can function within a transaction
 both independently of any external code that starts a transaction,
 as well as within a block that has already demarcated a transaction.
 

--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -740,7 +740,7 @@ class MSSQLCompiler(compiler.SQLCompiler):
                                         self.process(binary.right, **kw))
 
     def get_select_precolumns(self, select):
-        """ MS-SQL puts TOP, it's version of LIMIT here """
+        """ MS-SQL puts TOP, its version of LIMIT, here """
         if select._distinct or select._limit is not None:
             s = select._distinct and "DISTINCT " or ""
 

--- a/lib/sqlalchemy/dialects/oracle/cx_oracle.py
+++ b/lib/sqlalchemy/dialects/oracle/cx_oracle.py
@@ -499,7 +499,7 @@ class OracleExecutionContext_cx_oracle(OracleExecutionContext):
                     if dbtype is None:
                         raise exc.InvalidRequestError(
                                     "Cannot create out parameter for parameter "
-                                    "%r - it's type %r is not supported by"
+                                    "%r - its type %r is not supported by"
                                     " cx_oracle" %
                                     (bindparam.key, bindparam.type)
                                     )

--- a/lib/sqlalchemy/dialects/postgresql/psycopg2.py
+++ b/lib/sqlalchemy/dialects/postgresql/psycopg2.py
@@ -270,7 +270,7 @@ class _PGJSON(JSON):
         else:
             return super(_PGJSON, self).result_processor(dialect, coltype)
 
-# When we're handed literal SQL, ensure it's a SELECT-query. Since
+# When we're handed literal SQL, ensure it's a SELECT query. Since
 # 8.3, combining cursors and "FOR UPDATE" has been fine.
 SERVER_SIDE_CURSOR_RE = re.compile(
     r'\s*SELECT',

--- a/lib/sqlalchemy/dialects/type_migration_guidelines.txt
+++ b/lib/sqlalchemy/dialects/type_migration_guidelines.txt
@@ -114,7 +114,7 @@ linked to TypeEngine classes.
 
     a. The string name should be matched to the most specific type possible within
     sqlalchemy.types, unless there is no matching type within sqlalchemy.types in which
-    case it points to a dialect type.   *It doesn't matter* if the dialect has it's 
+    case it points to a dialect type.   *It doesn't matter* if the dialect has its 
     own subclass of that type with special bind/result behavior - reflect to the types.py
     UPPERCASE type as much as possible.   With very few exceptions, all types
     should reflect to an UPPERCASE type.

--- a/lib/sqlalchemy/engine/__init__.py
+++ b/lib/sqlalchemy/engine/__init__.py
@@ -9,7 +9,7 @@
 The engine package defines the basic components used to interface
 DB-API modules with higher-level statement construction,
 connection-management, execution and result contexts.  The primary
-"entry point" class into this package is the Engine and it's public
+"entry point" class into this package is the Engine and its public
 constructor ``create_engine()``.
 
 This package includes:

--- a/lib/sqlalchemy/engine/base.py
+++ b/lib/sqlalchemy/engine/base.py
@@ -122,7 +122,7 @@ class Connection(Connectable):
         execution options which will take effect for a call to
         :meth:`execute`. As the new :class:`.Connection` references the same
         underlying resource, it's usually a good idea to ensure that the copies
-        would be discarded immediately, which is implicit if used as in::
+        will be discarded immediately, which is implicit if used as in::
 
             result = connection.execution_options(stream_results=True).\\
                                 execute(stmt)

--- a/lib/sqlalchemy/engine/reflection.py
+++ b/lib/sqlalchemy/engine/reflection.py
@@ -523,7 +523,7 @@ class Inspector(object):
             table.primary_key.name = pk_cons.get('name')
 
             # tell the PKConstraint to re-initialize
-            # it's column collection
+            # its column collection
             table.primary_key._reload(pk_cols)
 
         fkeys = self.get_foreign_keys(table_name, schema, **table.dialect_kwargs)

--- a/lib/sqlalchemy/event/base.py
+++ b/lib/sqlalchemy/event/base.py
@@ -7,7 +7,7 @@
 """Base implementation classes.
 
 The public-facing ``Events`` serves as the base class for an event interface;
-it's public attributes represent different kinds of events.   These attributes
+its public attributes represent different kinds of events.   These attributes
 are mirrored onto a ``_Dispatch`` class, which serves as a container for
 collections of listener functions.   These collections are represented both
 at the class level of a particular ``_Dispatch`` class as well as within

--- a/lib/sqlalchemy/ext/compiler.py
+++ b/lib/sqlalchemy/ext/compiler.py
@@ -319,7 +319,7 @@ Example usage::
 -------------------
 
 The "GREATEST" function is given any number of arguments and returns the one
-that is of the highest value - it's equivalent to Python's ``max``
+that is of the highest value - its equivalent to Python's ``max``
 function.  A SQL standard version versus a CASE based version which only
 accommodates two arguments::
 

--- a/lib/sqlalchemy/orm/collections.py
+++ b/lib/sqlalchemy/orm/collections.py
@@ -445,7 +445,7 @@ class collection(object):
         The converter method will receive the object being assigned and should
         return an iterable of values suitable for use by the ``appender``
         method.  A converter must not assign values or mutate the collection,
-        it's sole job is to adapt the value the user provides into an iterable
+        its sole job is to adapt the value the user provides into an iterable
         of values for the ORM's use.
 
         The default converter implementation will use duck-typing to do the

--- a/lib/sqlalchemy/orm/deprecated_interfaces.py
+++ b/lib/sqlalchemy/orm/deprecated_interfaces.py
@@ -127,7 +127,7 @@ class MapperExtension(object):
         return EXT_CONTINUE
 
     def init_instance(self, mapper, class_, oldinit, instance, args, kwargs):
-        """Receive an instance when it's constructor is called.
+        """Receive an instance when its constructor is called.
 
         This method is only called during a userland construction of
         an object.  It is not called when an object is loaded from the
@@ -140,7 +140,7 @@ class MapperExtension(object):
         return EXT_CONTINUE
 
     def init_failed(self, mapper, class_, oldinit, instance, args, kwargs):
-        """Receive an instance when it's constructor has been called,
+        """Receive an instance when its constructor has been called,
         and raised an exception.
 
         This method is only called during a userland construction of

--- a/lib/sqlalchemy/orm/events.py
+++ b/lib/sqlalchemy/orm/events.py
@@ -213,7 +213,7 @@ class InstanceEvents(event.Events):
         """
 
     def init(self, target, args, kwargs):
-        """Receive an instance when it's constructor is called.
+        """Receive an instance when its constructor is called.
 
         This method is only called during a userland construction of
         an object.  It is not called when an object is loaded from the
@@ -222,7 +222,7 @@ class InstanceEvents(event.Events):
         """
 
     def init_failure(self, target, args, kwargs):
-        """Receive an instance when it's constructor has been called,
+        """Receive an instance when its constructor has been called,
         and raised an exception.
 
         This method is only called during a userland construction of
@@ -316,7 +316,7 @@ class InstanceEvents(event.Events):
         """
 
     def unpickle(self, target, state_dict):
-        """Receive an object instance after it's associated state has
+        """Receive an object instance after its associated state has
         been unpickled.
 
         :param target: the mapped instance.  If

--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -3284,7 +3284,7 @@ def _find_columns(clause):
 # however the inspect() versions add significant callcount
 # overhead for critical functions like _interpret_as_column_or_from().
 # Generally, the column-based functions are more performance critical
-# and are fine just checking for __clause_element__().  it's only
+# and are fine just checking for __clause_element__().  It is only
 # _interpret_as_from() where we'd like to be able to receive ORM entities
 # that have no defined namespace, hence inspect() is needed there.
 

--- a/lib/sqlalchemy/sql/functions.py
+++ b/lib/sqlalchemy/sql/functions.py
@@ -414,7 +414,7 @@ register_function("extract", Extract)
 
 class next_value(GenericFunction):
     """Represent the 'next value', given a :class:`.Sequence`
-    as it's single argument.
+    as its single argument.
 
     Compiles into the appropriate function on each backend,
     or will raise NotImplementedError if used on a backend

--- a/lib/sqlalchemy/sql/schema.py
+++ b/lib/sqlalchemy/sql/schema.py
@@ -1241,7 +1241,7 @@ class Column(SchemaItem, ColumnClause):
                 for f in self.foreign_keys]
         if name is None and self.name is None:
             raise exc.InvalidRequestError("Cannot initialize a sub-selectable"
-                    " with this Column object until it's 'name' has "
+                    " with this Column object until its 'name' has "
                     "been assigned.")
         try:
             c = self._constructor(

--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -469,7 +469,7 @@ class FromClause(Selectable):
         to its .c. collection when a Column has been added to one of the
         Table objects it ultimtely derives from.
 
-        If the given selectable hasn't populated it's .c. collection yet,
+        If the given selectable hasn't populated its .c. collection yet,
         it should at least pass on the message to the contained selectables,
         but it will return None.
 

--- a/lib/sqlalchemy/sql/sqltypes.py
+++ b/lib/sqlalchemy/sql/sqltypes.py
@@ -1054,7 +1054,7 @@ class Enum(String, SchemaType):
            operations. If the type is not associated with any ``MetaData``
            object, it will associate itself with each ``Table`` in which it is
            used, and will be created when any of those individual tables are
-           created, after a check is performed for it's existence. The type is
+           created, after a check is performed for its existence. The type is
            only dropped when ``drop_all()`` is called for that ``Table``
            object's metadata, however.
 

--- a/lib/sqlalchemy/testing/suite/test_types.py
+++ b/lib/sqlalchemy/testing/suite/test_types.py
@@ -20,7 +20,7 @@ class _LiteralRoundTripFixture(object):
         """test literal rendering """
 
         # for literal, we test the literal render in an INSERT
-        # into a typed column.  we can then SELECT it back as it's
+        # into a typed column.  we can then SELECT it back as its
         # official type; ideally we'd be able to use CAST here
         # but MySQL in particular can't CAST fully
         t = Table('t', self.metadata, Column('x', type_))

--- a/test/aaa_profiling/test_memusage.py
+++ b/test/aaa_profiling/test_memusage.py
@@ -338,7 +338,7 @@ class MemUsageTest(EnsureZeroed):
         i = [1]
 
         # the times here is cranked way up so that we can see
-        # pysqlite clearing out it's internal buffer and allow
+        # pysqlite clearing out its internal buffer and allow
         # the test to pass
         @testing.emits_warning()
         @profile_memory()

--- a/test/ext/test_automap.py
+++ b/test/ext/test_automap.py
@@ -123,7 +123,7 @@ class AutomapTest(fixtures.MappedTest):
         i1 = Item()
         o1.items_collection.add(i1)
 
-        # it's 'order_collection' because the class name is
+        # it is 'order_collection' because the class name is
         # "Order" !
         assert isinstance(i1.order_collection, list)
         assert o1 in i1.order_collection


### PR DESCRIPTION
Removed ungrammatical apostrophes from documentation, replacing
"it's" with "its" where appropriate (but in a few cases with "it is"
when that read better).

While doing that, I also fixed a couple of minor typos etc.
as I noticed them.
