### PR TITLE
Add a _proxyImpl helper class

### DIFF
--- a/lib/sqlalchemy/orm/descriptor_props.py
+++ b/lib/sqlalchemy/orm/descriptor_props.py
@@ -18,6 +18,9 @@ from ..sql import expression
 from . import properties
 from . import query
 
+class ProxyImpl(object):
+	"""A helper class for detecting whether an attribute is a proxy"""
+	pass
 
 class DescriptorProperty(MapperProperty):
     """:class:`.MapperProperty` which proxies access to a
@@ -28,7 +31,7 @@ class DescriptorProperty(MapperProperty):
     def instrument_class(self, mapper):
         prop = self
 
-        class _ProxyImpl(object):
+        class _ProxyImpl(ProxyImpl):
             accepts_scalar_loader = False
             expire_missing = True
             collection = False


### PR DESCRIPTION
If you can come up with a better test for this, that'd be even nicer.
(Formalchemy sure does some other somewhat-ugly things under the hood …)

formalchemy does the following:

```
    if isinstance(self._impl, ScalarAttributeImpl) or self._impl.__class__.__name__ == '_ProxyImpl': # ProxyImpl is a one-off class for each synonym, can't import it
        # normal property, mapped to a single column from the main table
        prop = getattr(self._property, '_proxied_property', None)
        if prop is None:
            prop = self._property
        return tuple(prop.local_columns)
```

With this patch, this test can be replaced with

```
    if isinstance(self._impl, (ScalarAttributeImpl,ProxyImpl):
        …
```
