### PR TITLE
once kwarg in event funcs is new in 0.9.4

### DIFF
--- a/lib/sqlalchemy/event/api.py
+++ b/lib/sqlalchemy/event/api.py
@@ -53,7 +53,7 @@ def listen(target, identifier, fn, *args, **kw):
 
         event.listen(Mapper, "before_configure", on_config, once=True)
 
-    .. versionadded:: 0.9.3 Added ``once=True`` to :func:`.event.listen`
+    .. versionadded:: 0.9.4 Added ``once=True`` to :func:`.event.listen`
        and :func:`.event.listens_for`.
 
     """
@@ -84,7 +84,7 @@ def listens_for(target, identifier, *args, **kw):
             do_config()
 
 
-    .. versionadded:: 0.9.3 Added ``once=True`` to :func:`.event.listen`
+    .. versionadded:: 0.9.4 Added ``once=True`` to :func:`.event.listen`
        and :func:`.event.listens_for`.
 
     """


### PR DESCRIPTION
event.listen and event.listen_for have a kwarg once added in 0.9.4 (not 0.9.3) CHANGELOG agrees with this as well. (as does my manual testing)
