### PR TITLE
Wrong type usage in StringTest

### DIFF
--- a/lib/sqlalchemy/testing/suite/test_types.py
+++ b/lib/sqlalchemy/testing/suite/test_types.py
@@ -208,7 +208,7 @@ class StringTest(_LiteralRoundTripFixture, fixtures.TestBase):
 
     def test_literal_backslashes(self):
         data = r'backslash one \ backslash two \\ end'
-        self._literal_round_trip(Text, [data], [data])
+        self._literal_round_trip(String(40), [data], [data])
 
 
 class _DateFixture(_LiteralRoundTripFixture):


### PR DESCRIPTION
The StringTest.test_literal_backslashes() method makes use of Type 'Text' instead of 'String'. This causes the test suite to fail for dialects that support String but not Text.
