### PR TITLE
Uninitialized local variable

### DIFF
--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -1967,14 +1967,15 @@ class SQLCompiler(Compiled):
         implicit_returning = need_pks and \
                                 self.dialect.implicit_returning and \
                                 stmt.table.implicit_returning
-
-        implicit_return_defaults = False
+                                
         if self.isinsert:
             implicit_return_defaults = implicit_returning and stmt._return_defaults
         elif self.isupdate:
             implicit_return_defaults = self.dialect.implicit_returning and \
                                 stmt.table.implicit_returning and \
                                 stmt._return_defaults
+        else:
+            implicit_return_defaults = False
 
         if implicit_return_defaults:
             if stmt._return_defaults is True:


### PR DESCRIPTION
implicit_return_defaults is not properly initialized. I am implementing a MERGE statement (inherits from Executable and ClauseElement) that is neither INSERT nor UPDATE. This causes access to the uninitialized variable in line 1979.
