### PR TITLE
Eliminate some reference cycles

### DIFF
--- a/lib/sqlalchemy/engine/base.py
+++ b/lib/sqlalchemy/engine/base.py
@@ -1236,8 +1236,12 @@ class Transaction(object):
 
     def __init__(self, connection, parent):
         self.connection = connection
-        self._parent = parent or self
+        self._actual_parent = parent
         self.is_active = True
+
+    @property
+    def _parent(self):
+        return self._actual_parent or self
 
     def close(self):
         """Close this :class:`.Transaction`.

--- a/lib/sqlalchemy/orm/relationships.py
+++ b/lib/sqlalchemy/orm/relationships.py
@@ -28,6 +28,7 @@ from .interfaces import MANYTOMANY, MANYTOONE, ONETOMANY, StrategizedProperty, P
 from ..inspection import inspect
 from . import mapper as mapperlib
 import collections
+import weakref
 
 def remote(expr):
     """Annotate a portion of a primaryjoin expression
@@ -1804,8 +1805,10 @@ def _annotate_columns(element, annotations):
     def clone(elem):
         if isinstance(elem, expression.ColumnClause):
             elem = elem._annotate(annotations.copy())
-        elem._copy_internals(clone=clone)
+        elem._copy_internals(clone=weak_clone)
         return elem
+
+    weak_clone = weakref.proxy(clone)
 
     if element is not None:
         element = clone(element)

--- a/lib/sqlalchemy/orm/session.py
+++ b/lib/sqlalchemy/orm/session.py
@@ -1000,6 +1000,7 @@ class Session(_SessionClassMethods):
         if self.transaction is not None:
             for transaction in self.transaction._iterate_parents():
                 transaction.close()
+            self.transaction = None
 
     def expunge_all(self):
         """Remove all object instances from this ``Session``.

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -29,6 +29,7 @@ from .. import util, exc
 import decimal
 import itertools
 import operator
+import weakref
 
 RESERVED_WORDS = set([
     'all', 'analyse', 'analyze', 'and', 'any', 'array',
@@ -382,7 +383,9 @@ class SQLCompiler(Compiled):
 
         # a map which tracks "anonymous" identifiers that are created on
         # the fly here
-        self.anon_map = util.PopulateDict(self._process_anon)
+        # weakref note: for some reason weakref.proxy(self._process_anon) wasn't enough here
+        weak_self = weakref.ref(self)
+        self.anon_map = util.PopulateDict(lambda key: weak_self()._process_anon(key))
 
         # a map which tracks "truncated" names based on
         # dialect.label_length or dialect.max_identifier_length

--- a/lib/sqlalchemy/sql/util.py
+++ b/lib/sqlalchemy/sql/util.py
@@ -8,6 +8,8 @@
 
 """
 
+import weakref
+
 from .. import exc, util
 from .base import _from_objects, ColumnSet
 from . import operators, visitors
@@ -547,7 +549,7 @@ class ColumnAdapter(ClauseAdapter):
         ClauseAdapter.__init__(self, selectable, equivalents, include, exclude)
         if chain_to:
             self.chain(chain_to)
-        self.columns = util.populate_column_dict(self._locate_col)
+        self.columns = util.populate_column_dict(weakref.proxy(self._locate_col))
         self.adapt_required = adapt_required
 
     def wrap(self, adapter):
@@ -556,7 +558,7 @@ class ColumnAdapter(ClauseAdapter):
         ac._locate_col = ac._wrap(ac._locate_col, adapter._locate_col)
         ac.adapt_clause = ac._wrap(ac.adapt_clause, adapter.adapt_clause)
         ac.adapt_list = ac._wrap(ac.adapt_list, adapter.adapt_list)
-        ac.columns = util.populate_column_dict(ac._locate_col)
+        ac.columns = util.populate_column_dict(weakref.proxy(ac._locate_col))
         return ac
 
     adapt_clause = ClauseAdapter.traverse

--- a/lib/sqlalchemy/sql/visitors.py
+++ b/lib/sqlalchemy/sql/visitors.py
@@ -26,6 +26,7 @@ http://techspot.zzzeek.org/2008/01/23/expression-transformations/
 from collections import deque
 from .. import util
 import operator
+import weakref
 from .. import exc
 
 __all__ = ['VisitableType', 'Visitable', 'ClauseVisitor',
@@ -306,8 +307,9 @@ def replacement_traverse(obj, opts, replace):
             else:
                 if elem not in cloned:
                     cloned[elem] = newelem = elem._clone()
-                    newelem._copy_internals(clone=clone, **kw)
+                    newelem._copy_internals(clone=weak_clone, **kw)
                 return cloned[elem]
+    weak_clone = weakref.proxy(clone)
 
     if obj is not None:
         obj = clone(obj, **opts)


### PR DESCRIPTION
Hi!
We're working on making Python garbage collector's life in our applications easier, one of the identified sources of frequently discarded object graphs with reference cycles is SQLAlchemy, I managed to find some low hanging fruits and modify the code, find the changes attached.

I left it split into individual commits for clarity - feel free to modify/squash/etc. I also left out unit tests as I'm not sure how should they be approached here.

Comments are welcome; please consider incorporate those changes in one form or another.