### PR TITLE
Tell mysql that Unicode columns are actually unicode

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -1991,6 +1991,13 @@ class MySQLTypeCompiler(compiler.GenericTypeCompiler):
                     "VARCHAR requires a length on dialect %s" %
                     self.dialect.name)
 
+    def visit_unicode(self, type_):
+        return self.visit_NVARCHAR(type_)
+
+    def visit_unicode_text(self, type_):
+        spec = "TEXT(%d)" % type_.length if type_.length else "TEXT"
+        return self._extend_string(type_, {"unicode": True}, spec)
+
     def visit_CHAR(self, type_):
         if type_.length:
             return self._extend_string(type_, {}, "CHAR(%(length)s)" %
@@ -2590,8 +2597,6 @@ class MySQLDialect(default.DefaultDialect):
         if not row:
             raise exc.NoSuchTableError(full_name)
         return row[1].strip()
-
-        return sql
 
     def _describe_table(self, connection, table, charset=None,
                              full_name=None):

--- a/test/dialect/mysql/test_types.py
+++ b/test/dialect/mysql/test_types.py
@@ -238,7 +238,13 @@ class TypesTest(fixtures.TestBase, AssertsExecutionResults, AssertsCompiledSQL):
             (mysql.ENUM, ["foo", "bar"], {'unicode':True},
              '''ENUM('foo','bar') UNICODE'''),
 
-            (String, [20], {"collation": "utf8"}, 'VARCHAR(20) COLLATE utf8')
+            (String, [20], {"collation": "utf8"}, 'VARCHAR(20) COLLATE utf8'),
+
+            (Unicode, [20], {}, 'NATIONAL VARCHAR(20)'),
+
+            (UnicodeText, [], {}, 'TEXT UNICODE'),
+
+            (UnicodeText, [20], {}, 'TEXT(20) UNICODE'),
 
 
            ]
@@ -252,7 +258,7 @@ class TypesTest(fixtures.TestBase, AssertsExecutionResults, AssertsCompiledSQL):
             # test that repr() copies out all arguments
             self.assert_compile(
                 eval("mysql.%r" % type_inst)
-                    if type_ is not String
+                    if type_ not in (String, Unicode, UnicodeText)
                     else eval("%r" % type_inst),
                 res
             )
@@ -820,4 +826,3 @@ class EnumSetTest(fixtures.TestBase, AssertsExecutionResults, AssertsCompiledSQL
 def colspec(c):
     return testing.db.dialect.ddl_compiler(
                     testing.db.dialect, None).get_column_specification(c)
-


### PR DESCRIPTION
Without this patch, Unicode columns get no special charset by default,
and fall back to whatever the table, database, server configuration
and (eventually) server hardcoded default encoding is.  The hardcoded
default mysql encoding is latin1.
