### PR TITLE
Fix doc gen on Windows platform

### DIFF
--- a/doc/build/builder/viewsource.py
+++ b/doc/build/builder/viewsource.py
@@ -167,7 +167,7 @@ class AutoSourceDirective(Directive):
         env = self.state.document.settings.env
         self.docname = env.docname
 
-        sourcefile = self.state.document.current_source.split(":")[0]
+        sourcefile = self.state.document.current_source.split(os.pathsep)[0]
         dir_ = os.path.dirname(sourcefile)
         files = [
             f for f in os.listdir(dir_) if f.endswith(".py")


### PR DESCRIPTION
- replaced hardcoded ":" path separator with OS dependent one.
