### PR TITLE
Fix argument to array() in array._bind_param()

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -695,7 +695,7 @@ class array(expression.Tuple):
         self.type = ARRAY(self.type)
 
     def _bind_param(self, operator, obj):
-        return array(*[
+        return array([
             expression.BindParameter(None, o, _compared_to_operator=operator,
                                      _compared_to_type=self.type, unique=True)
             for o in obj


### PR DESCRIPTION
array.**init**() expects a list as its sole parameter but inside _bind_param(), instead of sending a list it's sending each item in the list as a separate argument.
