### PR TITLE
Feature/postgres relkind

### DIFF
--- a/lib/sqlalchemy/engine/default.py
+++ b/lib/sqlalchemy/engine/default.py
@@ -107,7 +107,6 @@ class DefaultDialect(interfaces.Dialect):
     default_paramstyle = 'named'
     supports_default_values = False
     supports_empty_insert = True
-    supports_foreign_tables = False
     supports_multivalues_insert = False
 
     server_version_info = None

--- a/lib/sqlalchemy/engine/interfaces.py
+++ b/lib/sqlalchemy/engine/interfaces.py
@@ -319,12 +319,6 @@ class Dialect(object):
 
         raise NotImplementedError()
 
-    def get_foreign_table_names(self, connection, schema=None, **kw):
-        """Return a list of foreign table names for `schema`.
-        """
-
-        raise NotImplementedError()
-
     def get_view_definition(self, connection, view_name, schema=None, **kw):
         """Return view definition.
 

--- a/lib/sqlalchemy/engine/reflection.py
+++ b/lib/sqlalchemy/engine/reflection.py
@@ -227,6 +227,9 @@ class Inspector(object):
         :param schema: Optional, retrieve names from a non-default schema.
          For special quoting, use :class:`.quoted_name`.
 
+        .. versionchanged:: 1.0.0 now returns materialized views as well
+        as normal views.
+
         """
 
         return self.dialect.get_view_names(self.bind, schema,

--- a/lib/sqlalchemy/testing/requirements.py
+++ b/lib/sqlalchemy/testing/requirements.py
@@ -253,15 +253,6 @@ class SuiteRequirements(Requirements):
         return exclusions.closed()
 
     @property
-    def foreign_tables(self):
-        """target platform supports FOREIGN TABLEs."""
-
-        return exclusions.only_if(
-            lambda config: config.db.dialect.supports_foreign_tables,
-            "%(database)s %(does_support)s 'FOREIGN TABLEs'"
-        )
-
-    @property
     def schemas(self):
         """Target database must support external schemas, and have one
         named 'test_schema'."""
@@ -309,12 +300,6 @@ class SuiteRequirements(Requirements):
         """target database must support inspection of the full CREATE VIEW definition.
         """
         return self.views
-
-    @property
-    def foreign_table_reflection(self):
-        """target database must support inspection of the full CREATE FOREIGN TABLE definition.
-        """
-        return self.foreign_tables
 
     @property
     def schema_reflection(self):

--- a/test/dialect/postgresql/test_reflection.py
+++ b/test/dialect/postgresql/test_reflection.py
@@ -107,6 +107,12 @@ class AltRelkindReflectionTest(fixtures.TestBase, AssertsExecutionResults):
             (89, 'd1',)
         ]
 
+    def test_get_foreign_table_names(self):
+        inspector = inspect(testing.db)
+        connection = testing.db.connect()
+        ft_names = inspector.get_foreign_table_names(connection)
+        assert u'test_foreigntable' in ft_names
+
 
 class DomainReflectionTest(fixtures.TestBase, AssertsExecutionResults):
     """Test PostgreSQL domains"""


### PR DESCRIPTION
First run at fixing https://bitbucket.org/zzzeek/sqlalchemy/issue/2891/support-materialized-views-in-postgresql#comment-11769903
- Tables now take the postresql_relkind parameter in their constructor. This reflection option gets passed to get_table_oid() to filter its search for table oids. Can be full names (e.g. "materialized", "foreign", "view") or short-hand ("m", "f", "v", "r").
- get_table_oid() also always searches through tables with 'v' for backwards compatibility... Any better ideas on how to handle this?
- Added some basic tests for 'm' and 'f' relkinds. Added the postgres_test_db_link configuration for testing.

Another question: All calls to get_table_oid() need to come with table.dialect_kwargs to pass postgresql_relkind. Unfortunately, I couldn't find a way to reference table.dialect_kwargs from the get_unique_constraints method of the Inspector class. Any ideas on how to solve this?

https://github.com/rclmenezes/sqlalchemy/blob/feature/postgres-relkind/lib/sqlalchemy/engine/reflection.py#L385
