### PR TITLE
pg8000 dialect now supports client_encoding from create_engine()

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/pg8000.py
+++ b/lib/sqlalchemy/dialects/postgresql/pg8000.py
@@ -72,6 +72,7 @@ from .base import (
     PGDialect, PGCompiler, PGIdentifierPreparer, PGExecutionContext,
     _DECIMAL_TYPES, _FLOAT_TYPES, _INT_TYPES)
 import re
+from sqlalchemy.dialects.postgresql.json import JSON
 
 
 class _PGNumeric(sqltypes.Numeric):
@@ -100,6 +101,15 @@ class _PGNumeric(sqltypes.Numeric):
 class _PGNumericNoBind(_PGNumeric):
     def bind_processor(self, dialect):
         return None
+
+
+class _PGJSON(JSON):
+
+    def result_processor(self, dialect, coltype):
+        if dialect._dbapi_version > (1, 10, 1):
+            return None  # Has native JSON
+        else:
+            return super(_PGJSON, self).result_processor(dialect, coltype)
 
 
 class PGExecutionContext_pg8000(PGExecutionContext):
@@ -143,7 +153,8 @@ class PGDialect_pg8000(PGDialect):
         PGDialect.colspecs,
         {
             sqltypes.Numeric: _PGNumericNoBind,
-            sqltypes.Float: _PGNumeric
+            sqltypes.Float: _PGNumeric,
+            JSON: _PGJSON,
         }
     )
 

--- a/test/dialect/postgresql/test_dialect.py
+++ b/test/dialect/postgresql/test_dialect.py
@@ -99,11 +99,13 @@ class MiscTest(fixtures.TestBase, AssertsExecutionResults, AssertsCompiledSQL):
         assert 'will create implicit sequence' in msgs
         assert 'will create implicit index' in msgs
 
-    @testing.only_on('postgresql+psycopg2', 'psycopg2-specific feature')
+    @testing.only_on(
+        ['postgresql+psycopg2', 'postgresql+pg8000'],
+        'psycopg2/pg8000-specific feature')
     @engines.close_open_connections
     def test_client_encoding(self):
         c = testing.db.connect()
-        current_encoding = c.connection.connection.encoding
+        current_encoding = c.execute("show client_encoding").fetchone()[0]
         c.close()
 
         # attempt to use an encoding that's not
@@ -115,7 +117,8 @@ class MiscTest(fixtures.TestBase, AssertsExecutionResults, AssertsCompiledSQL):
 
         e = engines.testing_engine(options={'client_encoding': test_encoding})
         c = e.connect()
-        eq_(c.connection.connection.encoding, test_encoding)
+        new_encoding = c.execute("show client_encoding").fetchone()[0]
+        eq_(new_encoding, test_encoding)
 
     @testing.only_on(
         ['postgresql+psycopg2', 'postgresql+pg8000'],


### PR DESCRIPTION
Hi Mike, a couple of commits for the pg8000 dialect.

The first one makes the checking of the \__version\__ attribute cope with the version string you get in development when you use [Versioneer](https://github.com/warner/python-versioneer), as pg8000 does.

The second commit adds support for setting the client_encoding parameter from create_engine, in the same way as with psycopg2.