### PR TITLE
Docs: use layout.mako only when mako_layout=='html'

### DIFF
--- a/doc/build/Makefile
+++ b/doc/build/Makefile
@@ -100,7 +100,7 @@ devhelp:
 	@echo "# devhelp"
 
 epub:
-	$(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
+	$(SPHINXBUILD) -b epub -A mako_layout=epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
 	@echo
 	@echo "Build finished. The epub file is in $(BUILDDIR)/epub."
 

--- a/doc/build/templates/layout.mako
+++ b/doc/build/templates/layout.mako
@@ -32,6 +32,13 @@
 <%inherit file="${context['base']}"/>
 
 <%
+    if mako_layout == 'epub':
+        next.body()
+        return
+%>
+
+
+<%
 withsidebar = bool(toc) and current_page_name != 'index'
 %>
 


### PR DESCRIPTION
- https://readthedocs.org/projects/sqlalchemy/downloads/epub/latest/ renders with the full template which is unreadable on e-readers
- in the makefile the template-variable mako_layout is set for target: html. it can be used to render the epub using only the base template
