### PR TITLE
specialize schema reflection warnings

### DIFF
--- a/lib/sqlalchemy/dialects/firebird/base.py
+++ b/lib/sqlalchemy/dialects/firebird/base.py
@@ -609,8 +609,9 @@ class FBDialect(default.DefaultDialect):
             colspec = row['ftype'].rstrip()
             coltype = self.ischema_names.get(colspec)
             if coltype is None:
-                util.warn("Did not recognize type '%s' of column '%s'" %
-                          (colspec, name))
+                util.warn(exc.SAUnknownTypeReflectionWarning(
+                    "Did not recognize type '%s' of column '%s'" %
+                    (colspec, name)))
                 coltype = sqltypes.NULLTYPE
             elif issubclass(coltype, Integer) and row['fprec'] != 0:
                 coltype = NUMERIC(

--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -1600,9 +1600,9 @@ class MSDialect(default.DefaultDialect):
                     kwargs.pop('length')
 
             if coltype is None:
-                util.warn(
+                util.warn(exc.SAUnknownTypeReflectionWarning(
                     "Did not recognize type '%s' of column '%s'" %
-                    (type, name))
+                    (type, name)))
                 coltype = sqltypes.NULLTYPE
             else:
                 if issubclass(coltype, sqltypes.Numeric) and \

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -2904,10 +2904,14 @@ class MySQLTableDefinitionParser(object):
                 spec = m.groupdict()
                 spec['full'] = False
         if not spec:
-            util.warn("Unknown column definition %r" % line)
+            util.warn(exc.SAUnparsableTypeReflectionWarning(
+                "Unknown column definition %r" % line
+            ))
             return
         if not spec['full']:
-            util.warn("Incomplete reflection of column definition %r" % line)
+            util.warn(exc.SAIncompleteTypeReflectionWarning(
+                "Incomplete reflection of column definition %r" % line
+            ))
 
         name, type_, args, notnull = \
             spec['name'], spec['coltype'], spec['arg'], spec['notnull']
@@ -2915,8 +2919,10 @@ class MySQLTableDefinitionParser(object):
         try:
             col_type = self.dialect.ischema_names[type_]
         except KeyError:
-            util.warn("Did not recognize type '%s' of column '%s'" %
-                      (type_, name))
+            util.warn(exc.SAUnknownTypeReflectionWarning(
+                "Did not recognize type '%s' of column '%s'" %
+                (type_, name)
+            ))
             col_type = sqltypes.NullType
 
         # Column type positional arguments eg. varchar(32)

--- a/lib/sqlalchemy/dialects/oracle/base.py
+++ b/lib/sqlalchemy/dialects/oracle/base.py
@@ -232,7 +232,7 @@ in conjunction with the :class:`.Table` construct:
 
 import re
 
-from sqlalchemy import util, sql
+from sqlalchemy import util, sql, exc
 from sqlalchemy.engine import default, base, reflection
 from sqlalchemy.sql import compiler, visitors, expression
 from sqlalchemy.sql import (operators as sql_operators,
@@ -1137,8 +1137,9 @@ class OracleDialect(default.DefaultDialect):
                 try:
                     coltype = self.ischema_names[coltype]
                 except KeyError:
-                    util.warn("Did not recognize type '%s' of column '%s'" %
-                              (coltype, colname))
+                    util.warn(exc.SAUnknownTypeReflectionWarning(
+                        "Did not recognize type '%s' of column '%s'" %
+                        (coltype, colname)))
                     coltype = sqltypes.NULLTYPE
 
             cdict = {

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -2282,8 +2282,10 @@ class PGDialect(default.DefaultDialect):
             if is_array:
                 coltype = ARRAY(coltype)
         else:
-            util.warn("Did not recognize type '%s' of column '%s'" %
-                      (attype, name))
+            util.warn(exc.SAUnknownTypeReflectionWarning(
+                "Did not recognize type '%s' of column '%s'" %
+                (attype, name)
+            ))
             coltype = sqltypes.NULLTYPE
         # adjust the default value
         autoincrement = False
@@ -2505,17 +2507,17 @@ class PGDialect(default.DefaultDialect):
 
             if expr:
                 if idx_name != sv_idx_name:
-                    util.warn(
+                    util.warn(exc.SAUnsupportedIndexReflectionWarning(
                         "Skipped unsupported reflection of "
                         "expression-based index %s"
-                        % idx_name)
+                        % idx_name))
                 sv_idx_name = idx_name
                 continue
 
             if prd and not idx_name == sv_idx_name:
-                util.warn(
+                util.warn(exc.SAIncompleteIndexReflectionWarning(
                     "Predicate of partial index %s ignored during reflection"
-                    % idx_name)
+                    % idx_name))
                 sv_idx_name = idx_name
 
             index = indexes[idx_name]

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -987,10 +987,10 @@ class SQLiteDialect(default.DefaultDialect):
             try:
                 coltype = coltype(*[int(a) for a in args])
             except TypeError:
-                util.warn(
+                util.warn(exc.SAIncompleteTypeReflectionWarning(
                     "Could not instantiate type %s with "
                     "reflected arguments %s; using no arguments." %
-                    (coltype, args))
+                    (coltype, args)))
                 coltype = coltype()
         else:
             coltype = coltype()

--- a/lib/sqlalchemy/dialects/sybase/base.py
+++ b/lib/sqlalchemy/dialects/sybase/base.py
@@ -550,8 +550,9 @@ class SybaseDialect(default.DefaultDialect):
             # if is_array:
             #     coltype = ARRAY(coltype)
         else:
-            util.warn("Did not recognize type '%s' of column '%s'" %
-                      (type_, name))
+            util.warn(exc.SAUnknownTypeReflectionWarning(
+                "Did not recognize type '%s' of column '%s'" %
+                (type_, name)))
             coltype = sqltypes.NULLTYPE
 
         if default:

--- a/lib/sqlalchemy/engine/reflection.py
+++ b/lib/sqlalchemy/engine/reflection.py
@@ -605,9 +605,9 @@ class Inspector(object):
             flavor = index_d.get('type', 'index')
             if include_columns and \
                     not set(columns).issubset(include_columns):
-                util.warn(
+                util.warn(exc.SAOmittedIndexReflectionWarning(
                     "Omitting %s key for (%s), key covers omitted columns." %
-                    (flavor, ', '.join(columns)))
+                    (flavor, ', '.join(columns))))
                 continue
             # look for columns by orig name in cols_by_orig_name,
             # but support columns that are in-Python only as fallback
@@ -617,11 +617,11 @@ class Inspector(object):
                     idx_col = cols_by_orig_name[c] \
                         if c in cols_by_orig_name else table.c[c]
                 except KeyError:
-                    util.warn(
+                    util.warn(exc.SAIncompleteIndexReflectionWarning(
                         "%s key '%s' was not located in "
                         "columns for table '%s'" % (
                             flavor, c, table_name
-                        ))
+                        )))
                 else:
                     idx_cols.append(idx_col)
 

--- a/lib/sqlalchemy/exc.py
+++ b/lib/sqlalchemy/exc.py
@@ -368,3 +368,35 @@ class SAPendingDeprecationWarning(PendingDeprecationWarning):
 
 class SAWarning(RuntimeWarning):
     """Issued at runtime."""
+
+
+class SAIndexReflectionWarning(SAWarning):
+    """ Issued if an index cannot be reflected """
+
+
+class SAOmittedIndexReflectionWarning(SAIndexReflectionWarning):
+    """ Issued if an index is ignored, because of omitted columns """
+
+
+class SAIncompleteIndexReflectionWarning(SAIndexReflectionWarning):
+    """ Issued if an index is missing columns or predicates """
+
+
+class SAUnsupportedIndexReflectionWarning(SAIndexReflectionWarning):
+    """ Issued if an index type is not supported and hence not reflected """
+
+
+class SATypeReflectionWarning(SAWarning):
+    """ Issued if a type cannot be reflected """
+
+
+class SAUnknownTypeReflectionWarning(SATypeReflectionWarning):
+    """ Issued if the reflected type is not known to SQLAlchemy """
+
+
+class SAUnparsableTypeReflectionWarning(SATypeReflectionWarning):
+    """ Issued if the type info from the DB could not be parsed """
+
+
+class SAIncompleteTypeReflectionWarning(SATypeReflectionWarning):
+    """ Issued if the type reflection is incomplete """

--- a/lib/sqlalchemy/testing/assertions.py
+++ b/lib/sqlalchemy/testing/assertions.py
@@ -110,6 +110,9 @@ def _expect_warnings(exc_cls, messages):
     real_warn = warnings.warn
 
     def our_warn(msg, exception, *arg, **kw):
+        if isinstance(msg, Warning):
+            msg, exception = str(msg), type(msg)
+
         if not issubclass(exception, exc_cls):
             return real_warn(msg, exception, *arg, **kw)
 


### PR DESCRIPTION
This PR specializes the warnings issued in the reflection code. The use case is to deal with the different warning types differently from the outside. For example, I have some code lying around [1], which does some reflection work using SA. It doesn't need to care about certain warnings (say, index warnings or incomplete types), but needs to deal with others (it turns them into exceptions and works with those).

I'm not sure if the names are too long. Maybe you have ideas about shorter names :-)

[1] intend to publish it