### PR TITLE
changed dbapi_connnection to dbapi_connection

### DIFF
--- a/lib/sqlalchemy/events.py
+++ b/lib/sqlalchemy/events.py
@@ -338,7 +338,7 @@ class PoolEvents(event.Events):
 
         """
 
-    def reset(self, dbapi_connnection, connection_record):
+    def reset(self, dbapi_connection, connection_record):
         """Called before the "reset" action occurs for a pooled connection.
 
         This event represents


### PR DESCRIPTION
Removed one 'n' (notice the triple nnn) from the arg 'dbapi_connnection' of PoolEvents.reset
