### PR TITLE
Small improvement on FlushError can't update error message

### DIFF
--- a/lib/sqlalchemy/orm/persistence.py
+++ b/lib/sqlalchemy/orm/persistence.py
@@ -375,12 +375,12 @@ def _collect_update_commands(uowtransaction, table, states_to_update):
                     params[col.key] = history.added[0]
             else:
                 pk_params[col._label] = history.unchanged[0]
+            if pk_params[col._label] is None:
+                raise orm_exc.FlushError(
+                    "Can't update table %s using NULL for primary "
+                    "key value on column %s" % (table, col))
 
         if params or value_params:
-            if None in pk_params.values():
-                raise orm_exc.FlushError(
-                    "Can't update table using NULL for primary "
-                    "key value")
             params.update(pk_params)
             yield (
                 state, state_dict, params, mapper,

--- a/test/orm/test_unitofwork.py
+++ b/test/orm/test_unitofwork.py
@@ -2479,7 +2479,8 @@ class PartialNullPKTest(fixtures.MappedTest):
         t1.col2 = 5
         assert_raises_message(
             orm_exc.FlushError,
-            "Can't update table using NULL for primary key value",
+            "Can't update table t1 using NULL for primary "
+            "key value on column t1.col2",
             s.commit
         )
 
@@ -2492,7 +2493,8 @@ class PartialNullPKTest(fixtures.MappedTest):
         t1.col3 = 'hi'
         assert_raises_message(
             orm_exc.FlushError,
-            "Can't update table using NULL for primary key value",
+            "Can't update table t1 using NULL for primary "
+            "key value on column t1.col2",
             s.commit
         )
 


### PR DESCRIPTION
Output in the error message the table name and the column name.

The same error message improvement that in the previous PR. I noticed that whatever path the code takes inside the loop, `pk_params[col._label]` is always assign so it's safe to move the `if` statement inside the loop checking for this key's value in the dictionary.
