### PR TITLE
Report the type of unexpected expression objects

### DIFF
--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -3732,7 +3732,8 @@ def _literal_as_text(element, warn=False):
         return _const_expr(element)
     else:
         raise exc.ArgumentError(
-            "SQL expression object or string expected."
+            "SQL expression object or string expected, got object of type %r "
+            "instead" % type(element)
         )
 
 

--- a/test/sql/test_defaults.py
+++ b/test/sql/test_defaults.py
@@ -368,7 +368,8 @@ class DefaultTest(fixtures.TestBase):
         ):
             assert_raises_message(
                 sa.exc.ArgumentError,
-                "SQL expression object or string expected.",
+                "SQL expression object or string expected, got object of type "
+                "<type 'list'> instead",
                 t.select, [const]
             )
             assert_raises_message(


### PR DESCRIPTION
This patch reports the type of unexpected expression objects, which seems to be useful in tracking down the object itself.