### PR TITLE
Fix slice addressing of _AssociationList with python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.3"
+  - "3.4"
+install:
+  - "pip install ."
+script:
+  - "python -m pytest"

--- a/lib/sqlalchemy/ext/associationproxy.py
+++ b/lib/sqlalchemy/ext/associationproxy.py
@@ -527,7 +527,10 @@ class _AssociationList(_AssociationCollection):
         return self.setter(object, value)
 
     def __getitem__(self, index):
-        return self._get(self.col[index])
+        if not isinstance(index, slice):
+            return self._get(self.col[index])
+        else:
+            return [self._get(member) for member in self.col[index]]
 
     def __setitem__(self, index, value):
         if not isinstance(index, slice):

--- a/test/ext/test_associationproxy.py
+++ b/test/ext/test_associationproxy.py
@@ -912,6 +912,22 @@ class LazyLoadTest(fixtures.TestBase):
         self.assert_('_children' in p.__dict__)
         self.assert_(len(p._children) == 3)
 
+    def test_slicing_list(self):
+        Parent, Child = self.Parent, self.Child
+
+        mapper(Parent, self.table, properties={
+            '_children': relationship(Child, lazy='select',
+                                  collection_class=list)})
+
+        p = Parent('p')
+        p.children = ['a', 'b', 'c']
+
+        p = self.roundtrip(p)
+
+        self.assert_(len(p._children) == 3)
+        eq_('b', p.children[1])
+        eq_(['b', 'c'], p.children[-2:])
+
     def test_lazy_scalar(self):
         Parent, Child = self.Parent, self.Child
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,9 @@ setenv=
   DISABLE_SQLALCHEMY_CEXT=1
 
 # see also .coveragerc
-deps=coverage
+deps=pytest-cov
+     coverage
+     mock
 commands=
   python -m pytest --cov=sqlalchemy --cov-report term --cov-report xml \
     --exclude-tag memory-intensive \


### PR DESCRIPTION
I was trying to port some project of my company to python3 and unittests were failing while manipulating a list through `associationproxy`. I was puzzled until I figured `__getslice__` is not called by python3.

As explained in python documentation [1], `__getitem__` should support `slice` objects and this applies to python 2 and 3.

This fix is probably not sufficient and deserves some unittesting.

[1] https://docs.python.org/3/reference/datamodel.html?highlight=slice#object.__getitem__