### PR TITLE
Work with `psycopg2.extras.register_hstore` and `psycopg2.extras.register_json`

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/hstore.py
+++ b/lib/sqlalchemy/dialects/postgresql/hstore.py
@@ -272,7 +272,14 @@ class HSTORE(sqltypes.Concatenable, sqltypes.TypeEngine):
             return sqltypes.Concatenable.Comparator.\
                 _adapt_expression(self, op, other_comparator)
 
+    def __init__(self, hstore_registered=False):
+        self.hstore_registered = hstore_registered
+        super(HSTORE, self).__init__()
+
     def bind_processor(self, dialect):
+        if self.hstore_registered:
+            return (lambda o: o)
+
         if util.py2k:
             encoding = dialect.encoding
 
@@ -290,6 +297,9 @@ class HSTORE(sqltypes.Concatenable, sqltypes.TypeEngine):
         return process
 
     def result_processor(self, dialect, coltype):
+        if self.hstore_registered:
+            return (lambda o: o)
+
         if util.py2k:
             encoding = dialect.encoding
 

--- a/lib/sqlalchemy/dialects/postgresql/json.py
+++ b/lib/sqlalchemy/dialects/postgresql/json.py
@@ -164,7 +164,7 @@ class JSON(sqltypes.TypeEngine):
 
     __visit_name__ = 'JSON'
 
-    def __init__(self, none_as_null=False):
+    def __init__(self, none_as_null=False, json_registered=False):
         """Construct a :class:`.JSON` type.
 
         :param none_as_null: if True, persist the value ``None`` as a
@@ -180,6 +180,7 @@ class JSON(sqltypes.TypeEngine):
 
          """
         self.none_as_null = none_as_null
+        self.json_registered = json_registered
 
     class comparator_factory(sqltypes.Concatenable.Comparator):
         """Define comparison operations for :class:`.JSON`."""
@@ -197,6 +198,9 @@ class JSON(sqltypes.TypeEngine):
                 _adapt_expression(self, op, other_comparator)
 
     def bind_processor(self, dialect):
+        if self.json_registered:
+            return (lambda o: o)
+
         json_serializer = dialect._json_serializer or json.dumps
         if util.py2k:
             encoding = dialect.encoding
@@ -217,6 +221,9 @@ class JSON(sqltypes.TypeEngine):
         return process
 
     def result_processor(self, dialect, coltype):
+        if self.json_registered:
+            return (lambda o: o)
+
         json_deserializer = dialect._json_deserializer or json.loads
         if util.py2k:
             encoding = dialect.encoding


### PR DESCRIPTION
Some psycopg2 connections will call `register_hstore` or `register_json` on them, for example in `django` projects with `django_hstore` app installed and `HAS_HSTORE` option set. Sqlalchemy's PostgreSQL dialect don't work properly under such circumstances, which is solved by this pull request.