### PR TITLE
fix Python 2-specific byte conversion

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -881,7 +881,9 @@ class BIT(sqltypes.TypeEngine):
         def process(value):
             if value is not None:
                 v = 0
-                for i in map(ord, value):
+                for i in value:
+                    if not isinstance(i, int):
+                        i = ord(i)  # convert byte to int on Python 2
                     v = v << 8 | i
                 return v
             return value


### PR DESCRIPTION
Currently, BIT fields in MySQL are broken on Python 3.

Basically, what the code is doing here is converting the value in the BIT field to a number, one byte at a time. On Python 2, the way to turn a byte into a number is `ord()`, but on Python 3, that's redundant; iterating over `bytes` already gives you numbers. Which produces the following error:

```TypeError: ord() expected string of length 1, but int found```

With a quick check of the code, I was able to find another similar issue in `lib/sqlalchemy/util/compat.py`. There may be others as well.

As an aside, do we really need to convert a bit *one byte at a time*? I suspect this code would work just as well:

```python
def process(value):
    if value is None:
        return None
    return ord(value)  # this should work on Python 2 or 3
```
