### PR TITLE
Accept unicode in CascadeOptions

### DIFF
--- a/lib/sqlalchemy/orm/util.py
+++ b/lib/sqlalchemy/orm/util.py
@@ -35,7 +35,7 @@ class CascadeOptions(frozenset):
         'expunge', 'delete_orphan')
 
     def __new__(cls, value_list):
-        if isinstance(value_list, str) or value_list is None:
+        if isinstance(value_list, util.string_types) or value_list is None:
             return cls.from_string(value_list)
         values = set(value_list)
         if values.difference(cls._allowed_cascades):

--- a/test/orm/test_cascade.py
+++ b/test/orm/test_cascade.py
@@ -2,7 +2,7 @@ import copy
 
 from sqlalchemy.testing import assert_raises, assert_raises_message
 from sqlalchemy import Integer, String, ForeignKey, Sequence, \
-    exc as sa_exc
+    exc as sa_exc, util
 from sqlalchemy.testing.schema import Table, Column
 from sqlalchemy.orm import mapper, relationship, create_session, \
     sessionmaker, class_mapper, backref, Session, util as orm_util,\
@@ -118,6 +118,14 @@ class CascadeArgTest(fixtures.MappedTest):
             set(['delete', 'delete-orphan', 'expunge', 'merge',
                     'refresh-expire', 'save-update'])
             )
+
+    def test_cascade_unicode(self):
+        User, Address = self.classes.User, self.classes.Address
+        users, addresses = self.tables.users, self.tables.addresses
+
+        rel = relationship(Address)
+        rel.cascade = util.u('save-update, merge, expunge')
+        eq_(rel.cascade, set(['save-update', 'merge', 'expunge']))
 
 
 class O2MCascadeDeleteOrphanTest(fixtures.MappedTest):


### PR DESCRIPTION
`cascade` should also accept unicode, instead of raising something like `ArgumentError: Invalid cascade option(s): u' ', u',', u'-', u'a', u'd', u'e', u'g', u'm', u'n', u'p', u'r', u's', u't', u'u', u'v', u'x'`