### PR TITLE
Fix typos in docs

### DIFF
--- a/doc/build/orm/extensions/declarative/mixins.rst
+++ b/doc/build/orm/extensions/declarative/mixins.rst
@@ -410,7 +410,7 @@ name based on class name::
 Alternatively, we can modify our ``__tablename__`` function to return
 ``None`` for subclasses, using :func:`.has_inherited_table`.  This has
 the effect of those subclasses being mapped with single table inheritance
-agaisnt the parent::
+against the parent::
 
     from sqlalchemy.ext.declarative import declared_attr
     from sqlalchemy.ext.declarative import has_inherited_table

--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -948,7 +948,7 @@ class Join(FromClause):
         """return an alias of this :class:`.Join`.
 
         The default behavior here is to first produce a SELECT
-        construct from this :class:`.Join`, then to produce a
+        construct from this :class:`.Join`, then to produce an
         :class:`.Alias` from that.  So given a join of the form::
 
             j = table_a.join(table_b, table_a.c.id == table_b.c.a_id)


### PR DESCRIPTION
agaisnt -> against
'a Alias' -> 'an Alias'