### PR TITLE
micro-optimize unique_list

### DIFF
--- a/lib/sqlalchemy/util/_collections.py
+++ b/lib/sqlalchemy/util/_collections.py
@@ -743,15 +743,16 @@ _property_getters = PopulateDict(
 
 
 def unique_list(seq, hashfunc=None):
-    seen = {}
+    seen = set()
+    seen_add = seen.add
     if not hashfunc:
         return [x for x in seq
                 if x not in seen
-                and not seen.__setitem__(x, True)]
+                and not seen_add(x)]
     else:
         return [x for x in seq
                 if hashfunc(x) not in seen
-                and not seen.__setitem__(hashfunc(x), True)]
+                and not seen_add(hashfunc(x))]
 
 
 class UniqueAppender(object):


### PR DESCRIPTION
This makes unique_list approx 2x faster in my (simple) tests for larg-ish sequences, and a bit faster for smaller ones.

```python
In [1]: def unique_list(seq):
   ...:     seen = {}
   ...:     return [x for x in seq
   ...:             if x not in seen
   ...:             and not seen.__setitem__(x, True)]
   ...: 

In [2]: def unique_list2(seq):
   ...:     seen = set()
   ...:     seen_add = seen.add
   ...:     return [x for x in seq
   ...:             if x not in seen
   ...:             and not seen_add(x)]
   ...: 

In [3]: l = list(range(10000))

In [5]: timeit unique_list(l)
100 loops, best of 3: 2.46 ms per loop

In [7]: timeit unique_list2(l)
1000 loops, best of 3: 1.1 ms per loop

In [8]: l = list(range(3))

In [9]: timeit unique_list(l)
1000000 loops, best of 3: 978 ns per loop

In [10]: timeit unique_list2(l)
1000000 loops, best of 3: 702 ns per loop

In [14]: l = list(range(int(1e6)))

In [15]: timeit unique_list(l)
1 loops, best of 3: 305 ms per loop

In [17]: timeit unique_list2(l)
1 loops, best of 3: 159 ms per loop
```