### PR TITLE
Mark tests that they require OFFSET support in database

### DIFF
--- a/lib/sqlalchemy/testing/suite/test_select.py
+++ b/lib/sqlalchemy/testing/suite/test_select.py
@@ -131,6 +131,7 @@ class LimitOffsetTest(fixtures.TablesTest):
             [(1, 1, 2), (2, 2, 3)]
         )
 
+    @testing.requires.offset
     def test_simple_offset(self):
         table = self.tables.some_table
         self._assert_result(
@@ -138,13 +139,15 @@ class LimitOffsetTest(fixtures.TablesTest):
             [(3, 3, 4), (4, 4, 5)]
         )
 
+    @testing.requires.offset
     def test_simple_limit_offset(self):
         table = self.tables.some_table
         self._assert_result(
             select([table]).order_by(table.c.id).limit(2).offset(1),
             [(2, 2, 3), (3, 3, 4)]
         )
-
+    
+    @testing.requires.offset
     def test_limit_offset_nobinds(self):
         """test that 'literal binds' mode works - no bound params."""
 


### PR DESCRIPTION
The sqlalchemy_exasol dialect needs to support Exasol 4.x which does not support 
the OFFSET feature. Mark test with testing.requires.offset so that they can be skipped
of in the exasol specific test suite.