### PR TITLE
Fixed unpickle bug when val in ext.mutable.values has no _parents

### DIFF
--- a/lib/sqlalchemy/ext/mutable.py
+++ b/lib/sqlalchemy/ext/mutable.py
@@ -478,7 +478,7 @@ class MutableBase(object):
 
         def pickle(state, state_dict):
             val = state.dict.get(key, None)
-            if val is not None:
+            if val is not None and hasattr(val, '_parents'):
                 if 'ext.mutable.values' not in state_dict:
                     state_dict['ext.mutable.values'] = []
                 state_dict['ext.mutable.values'].append(val)


### PR DESCRIPTION
It happens on these conditions:

1. ``expire_on_commit=False`` option on Session.
2. Using a custom type, such as JSONEncodedDict.
3. Column with a default value.

Here is an example::

    class Foo(Base):
        id = Column(Integer, primary_key=True)
        info = Column(JSONEncodedDict, default={})

Saving a Foo instance into memcache, and then get it out of memcache. It
would raise an exception:

```
    def unpickle(state, state_dict):
        if 'ext.mutable.values' in state_dict:
            for val in state_dict['ext.mutable.values']:
>               val._parents[state.obj()] = key
E               AttributeError: 'dict' object has no attribute '_parents'
```

Because the saved value in pickle function is a pure dict. It has no
'_parents'.