### PR TITLE
Update to correct TDS version; FreeTDS only supports up to 7.3. 8.0 i…

### DIFF
--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -1566,11 +1566,15 @@ class MSDialect(default.DefaultDialect):
             # FreeTDS with version 4.2 seems to report here
             # a number like "95.10.255".  Don't know what
             # that is.  So emit warning.
+            # Use TDS Version 7.0 through 7.3, per the MS information here:
+            # https://msdn.microsoft.com/en-us/library/dd339982.aspx
+            # and FreeTDS information here (7.3 highest supported version):
+            # http://www.freetds.org/userguide/choosingtdsprotocol.htm
             util.warn(
                 "Unrecognized server version info '%s'.   Version specific "
                 "behaviors may not function properly.   If using ODBC "
-                "with FreeTDS, ensure server version 7.0 or 8.0, not 4.2, "
-                "is configured in the FreeTDS configuration." %
+                "with FreeTDS, ensure TDS_VERSION 7.0 through 7.3, not "
+                "4.2, is configured in the FreeTDS configuration." %
                 ".".join(str(x) for x in self.server_version_info))
         if self.server_version_info >= MS_2005_VERSION and \
                 'implicit_returning' not in self.__dict__:


### PR DESCRIPTION
…s not a valid version (Microsoft released the spec late).

Just a minor update; it doesn't fix anything now, but may bulletproof the future. The highest version of TDS supported by FreeTDS is version 7.3. Microsoft released the official version numbering after FreeTDS supported the new feature set, which most people assumed would be 8.0. However, Microsoft actually ended up numbering the version 7.3. Although a 7.4 release has happened since (with some new features), FreeTDS only support 7.3.