### PR TITLE
Add support for PostgreSQL index storage options, and reflection of index storage options and index access methods

### DIFF
--- a/test/dialect/postgresql/test_compiler.py
+++ b/test/dialect/postgresql/test_compiler.py
@@ -369,6 +369,30 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
                             'USING hash (data)',
                             dialect=postgresql.dialect())
 
+    def test_create_index_with_with(self):
+        m = MetaData()
+        tbl = Table('testtbl', m, Column('data', String))
+
+        idx1 = Index('test_idx1', tbl.c.data)
+        idx2 = Index('test_idx2', tbl.c.data, postgresql_with={"fillfactor": 50})
+        idx3 = Index('test_idx3', tbl.c.data, postgresql_using="gist",
+                     postgresql_with={"buffering": "off"})
+
+        self.assert_compile(schema.CreateIndex(idx1),
+                            'CREATE INDEX test_idx1 ON testtbl '
+                            '(data)',
+                            dialect=postgresql.dialect())
+        self.assert_compile(schema.CreateIndex(idx2),
+                            'CREATE INDEX test_idx2 ON testtbl '
+                            '(data) '
+                            'WITH (fillfactor = 50)',
+                            dialect=postgresql.dialect())
+        self.assert_compile(schema.CreateIndex(idx3),
+                            'CREATE INDEX test_idx3 ON testtbl '
+                            'USING gist (data) '
+                            'WITH (buffering = off)',
+                            dialect=postgresql.dialect())
+
     def test_create_index_expr_gets_parens(self):
         m = MetaData()
         tbl = Table('testtbl', m, Column('x', Integer), Column('y', Integer))

--- a/test/dialect/postgresql/test_reflection.py
+++ b/test/dialect/postgresql/test_reflection.py
@@ -673,6 +673,26 @@ class ReflectionTest(fixtures.TestBase):
         conn.close()
 
     @testing.provide_metadata
+    def test_index_reflection_with_storage_options(self):
+        """reflect indexes with storage options set"""
+
+        metadata = self.metadata
+
+        t1 = Table('t', metadata,
+                   Column('id', Integer, primary_key=True),
+                   Column('x', Integer)
+                   )
+        metadata.create_all()
+        conn = testing.db.connect().execution_options(autocommit=True)
+        conn.execute("CREATE INDEX idx1 ON t (x) WITH (fillfactor = 50)")
+
+        ind = testing.db.dialect.get_indexes(conn, "t", None)
+        eq_(ind, [{'unique': False, 'column_names': ['x'], 'name': 'idx1',
+                   'dialect_options': {"postgresql_with": {"fillfactor": "50"}}}])
+        conn.close()
+
+
+    @testing.provide_metadata
     def test_foreign_key_option_inspection(self):
         metadata = self.metadata
         Table(


### PR DESCRIPTION
Add support for specifying PostgreSQL index storage paramters (e.g.
fillfactor).

See http://www.postgresql.org/docs/9.4/static/sql-createindex.html#SQL-CREATEINDEX-STORAGE-PARAMETERS