### PR TITLE
Expire session in testing transaction handling

### DIFF
--- a/doc/build/orm/session_transaction.rst
+++ b/doc/build/orm/session_transaction.rst
@@ -484,7 +484,9 @@ everything is rolled back.
 
       from sqlalchemy import event
 
+
       class SomeTest(TestCase):
+
           def setUp(self):
               # connect to the database
               self.connection = engine.connect()
@@ -503,6 +505,6 @@ everything is rolled back.
               def restart_savepoint(session, transaction):
                   if transaction.nested and not transaction._parent.nested:
                       session.begin_nested()
-
+                      session.expire_all()
 
           # ... the tearDown() method stays the same


### PR DESCRIPTION
Would you recommend this? For some reason, the session is not expired which can lead to weird behavior where the objects will still be in the session's identity map after the rollback/commit.

Maybe something else is wrong in how I handle tests though.