### PR TITLE
Fix/rmod

### DIFF
--- a/lib/sqlalchemy/sql/operators.py
+++ b/lib/sqlalchemy/sql/operators.py
@@ -597,6 +597,14 @@ class ColumnOperators(Operators):
         """
         return self.reverse_operate(div, other)
 
+    def __rmod__(self, other):
+        """Implement the ``%`` operator in reverse.
+
+        See :meth:`.ColumnOperators.__mod__`.
+
+        """
+        return self.reverse_operate(mod, other)
+
     def between(self, cleft, cright, symmetric=False):
         """Produce a :func:`~.expression.between` clause against
         the parent object, given the lower and upper range.

--- a/test/sql/test_operators.py
+++ b/test/sql/test_operators.py
@@ -1327,6 +1327,9 @@ class MathOperatorTest(fixtures.TestBase, testing.AssertsCompiledSQL):
         else:
             self._test_math_op(operator.div, '/')
 
+    def test_math_op_mod(self):
+        self._test_math_op(operator.mod, '%')
+
 
 class ComparisonOperatorTest(fixtures.TestBase, testing.AssertsCompiledSQL):
     __dialect__ = 'default'


### PR DESCRIPTION
Hi.
The reflected modulo operator (rmod) is not implemented in v1.0.6. As all other arithmetic operators (add, sub, mul, div and even truediv) are, I assume it's not intentional, so I implemented it, and even added a test for the modulo operator (which was also missing).