### PR TITLE
Don't get reloptions for PostgreSQL versions older than 8.5 when refl…

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -2641,7 +2641,7 @@ class PGDialect(default.DefaultDialect):
                   i.relname as relname,
                   ix.indisunique, ix.indexprs, ix.indpred,
                   a.attname, a.attnum, NULL, ix.indkey%s,
-                  i.reloptions, am.amname
+                  NULL, am.amname
               FROM
                   pg_class t
                         join pg_index ix on t.oid = ix.indrelid


### PR DESCRIPTION
…ecting indexes

reloptions were actually introduced in 8.2; this is really just for Amazon Redshift
which is based on PostgreSQL 8.0.2.