### PR TITLE
Support get_schema_names for SQLite dialect

### DIFF
--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -1095,6 +1095,13 @@ class SQLiteDialect(default.DefaultDialect):
             return None
 
     @reflection.cache
+    def get_schema_names(self, connection, **kw):
+        s = "PRAGMA database_list"
+        dl = connection.execute(s)
+
+        return [db[1] for db in dl]
+
+    @reflection.cache
     def get_table_names(self, connection, schema=None, **kw):
         if schema is not None:
             qschema = self.identifier_preparer.quote_identifier(schema)

--- a/test/dialect/test_sqlite.py
+++ b/test/dialect/test_sqlite.py
@@ -581,6 +581,11 @@ class AttachedMemoryDBTest(fixtures.TestBase):
         insp = inspect(self.conn)
         eq_(insp.get_table_names("test_schema"), ["created"])
 
+    def test_schema_names(self):
+        self._fixture()
+        insp = inspect(self.conn)
+        eq_(insp.get_schema_names(), ["main", "test_schema"])
+
     def test_reflect_system_table(self):
         meta = MetaData(self.conn)
         alt_master = Table(


### PR DESCRIPTION
Add support for get_schema_names for attached databases in SQLite.

This reports the "main" database by default as well. I wasn't sure if this should actually be supported, but it's consistent with the .databases command that you can run via the CLI.