### PR TITLE
When regexp match fails, report the bad string and the regexp used.

### DIFF
--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -526,16 +526,20 @@ class _MSDate(sqltypes.Date):
                 return value
         return process
 
-    _reg = re.compile(r"(\d+)-(\d+)-(\d+)")
+    _reg_str = r"(\d+)-(\d+)-(\d+)"
+    _reg = re.compile(_reg_str)
 
     def result_processor(self, dialect, coltype):
         def process(value):
             if isinstance(value, datetime.datetime):
                 return value.date()
             elif isinstance(value, util.string_types):
+                m = self._reg.match(value)
+                if not m:
+                    raise Exception("could not parse value {0} with MSDate regexp {1}".format(value, self._reg_str))
                 return datetime.date(*[
                     int(x or 0)
-                    for x in self._reg.match(value).groups()
+                    for x in m.groups()
                 ])
             else:
                 return value
@@ -560,16 +564,20 @@ class TIME(sqltypes.TIME):
             return value
         return process
 
-    _reg = re.compile(r"(\d+):(\d+):(\d+)(?:\.(\d{0,6}))?")
+    _reg_str = r"(\d+):(\d+):(\d+)(?:\.(\d{0,6}))?"
+    _reg = re.compile(_reg_str)
 
     def result_processor(self, dialect, coltype):
         def process(value):
             if isinstance(value, datetime.datetime):
                 return value.time()
             elif isinstance(value, util.string_types):
+                m = self._reg.match(value)
+                if not m:
+                    raise Exception("could not parse value {0} with TIME regexp {1}".format(value, self._reg_str))
                 return datetime.time(*[
                     int(x or 0)
-                    for x in self._reg.match(value).groups()])
+                    for x in m.groups()])
             else:
                 return value
         return process

--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -536,7 +536,7 @@ class _MSDate(sqltypes.Date):
             elif isinstance(value, util.string_types):
                 m = self._reg.match(value)
                 if not m:
-                    raise Exception("could not parse value {0} with MSDate regexp {1}".format(value, self._reg_str))
+                    raise Exception("could not parse value {0} as a _MSDate".format(value))
                 return datetime.date(*[
                     int(x or 0)
                     for x in m.groups()
@@ -574,7 +574,7 @@ class TIME(sqltypes.TIME):
             elif isinstance(value, util.string_types):
                 m = self._reg.match(value)
                 if not m:
-                    raise Exception("could not parse value {0} with TIME regexp {1}".format(value, self._reg_str))
+                    raise Exception("could not parse value {0} as a TIME".format(value))
                 return datetime.time(*[
                     int(x or 0)
                     for x in m.groups()])

--- a/test/dialect/mssql/test_types.py
+++ b/test/dialect/mssql/test_types.py
@@ -33,6 +33,18 @@ class TimeTypeTest(fixtures.TestBase):
         result_processor = mssql_time_type.result_processor(None, None)
         eq_(expected, result_processor(value))
 
+    def test_result_processor_invalid(self):
+        mssql_time_type = TIME()
+        result_processor = mssql_time_type.result_processor(None, None)
+        ex = None
+        bogus_value = 'abc'
+        try:
+            result_processor(bogus_value)
+        except Exception as caught:
+            ex = str(caught)
+        expected = 'could not parse value ' + bogus_value + ' as a TIME'
+        eq_(expected, ex)
+
 
 class MSDateTypeTest(fixtures.TestBase):
 
@@ -44,6 +56,18 @@ class MSDateTypeTest(fixtures.TestBase):
         mssql_date_type = _MSDate()
         result_processor = mssql_date_type.result_processor(None, None)
         eq_(expected, result_processor(value))
+
+    def test_result_processor_invalid(self):
+        mssql_date_type = _MSDate()
+        result_processor = mssql_date_type.result_processor(None, None)
+        ex = None
+        bogus_value = 'abc'
+        try:
+            result_processor(bogus_value)
+        except Exception as caught:
+            ex = str(caught)
+        expected = 'could not parse value ' + bogus_value + ' as a _MSDate'
+        eq_(expected, ex)
 
 
 class TypeDDLTest(fixtures.TestBase):

--- a/test/dialect/mssql/test_types.py
+++ b/test/dialect/mssql/test_types.py
@@ -8,7 +8,7 @@ from sqlalchemy import Table, Column, MetaData, Float, \
     UnicodeText, LargeBinary
 from sqlalchemy import types, schema
 from sqlalchemy.databases import mssql
-from sqlalchemy.dialects.mssql.base import TIME
+from sqlalchemy.dialects.mssql.base import TIME, _MSDate
 from sqlalchemy.testing import fixtures, \
     AssertsExecutionResults, ComparesTables
 from sqlalchemy import testing
@@ -31,6 +31,18 @@ class TimeTypeTest(fixtures.TestBase):
     def _assert_result_processor(self, expected, value):
         mssql_time_type = TIME()
         result_processor = mssql_time_type.result_processor(None, None)
+        eq_(expected, result_processor(value))
+
+
+class MSDateTypeTest(fixtures.TestBase):
+
+    def test_result_processor(self):
+        expected = datetime.date(2000, 1, 2)
+        self._assert_result_processor(expected, '2000-01-02')
+
+    def _assert_result_processor(self, expected, value):
+        mssql_date_type = _MSDate()
+        result_processor = mssql_date_type.result_processor(None, None)
         eq_(expected, result_processor(value))
 
 


### PR DESCRIPTION
On Fedora 22, connecting to Microsoft SQL Server 2008 R2, I see some strange errors when fetching the 'date' type.  It fails when trying to call `groups()` on `None`, because the regexp did not match earlier.  This patch at least checks that the regexp succeeds, and reports what went wrong if it failed.

I am still tracking down exactly why the SQL server returns values which don't match the regexp (they look like binary junk) but I suggest that checking for a successful match before calling `groups()` is good practice in any case.