### PR TITLE
Docstring typo in base.py

### DIFF
--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -186,7 +186,7 @@ CREATE TABLE statement for this column will yield::
 LIMIT/OFFSET Support
 --------------------
 
-MSSQL has no support for the LIMIT or OFFSET keysowrds. LIMIT is
+MSSQL has no support for the LIMIT or OFFSET keywords. LIMIT is
 supported directly through the ``TOP`` Transact SQL keyword::
 
     select.limit


### PR DESCRIPTION
Docstring typo keysowrds => keywords