### PR TITLE
Change generator termination from StopIteration to return.

### DIFF
--- a/lib/sqlalchemy/engine/result.py
+++ b/lib/sqlalchemy/engine/result.py
@@ -712,7 +712,7 @@ class ResultProxy(object):
         while True:
             row = self.fetchone()
             if row is None:
-                raise StopIteration
+                return
             else:
                 yield row
 

--- a/lib/sqlalchemy/ext/associationproxy.py
+++ b/lib/sqlalchemy/ext/associationproxy.py
@@ -603,7 +603,7 @@ class _AssociationList(_AssociationCollection):
 
         for member in self.col:
             yield self._get(member)
-        raise StopIteration
+        return
 
     def append(self, value):
         item = self._create(value)
@@ -907,7 +907,7 @@ class _AssociationSet(_AssociationCollection):
         """
         for member in self.col:
             yield self._get(member)
-        raise StopIteration
+        return
 
     def add(self, value):
         if value not in self:


### PR DESCRIPTION
From [PEP 479](https://www.python.org/dev/peps/pep-0479/) the correct way to terminate a generator is to return (which implicitly raises StopIteration) rather than raise StopIteration.

Without this change using sqlalchemy in python 3.5 or greater results in these warnings

    PendingDeprecationWarning: generator '__iter__' raised StopIteration

which this commit should remove.