### PR TITLE
py2k: accept unicode literals on :func:`backref`, too

### DIFF
--- a/doc/build/changelog/changelog_11.rst
+++ b/doc/build/changelog/changelog_11.rst
@@ -22,6 +22,14 @@
     :version: 1.1.0b1
 
     .. change::
+        :tags: bug, orm, declarative
+        :pullreq: github:212
+
+        Fixed bug where in Py2K a unicode literal would not be accepted as the
+        string name of a class or other argument within declarative using
+        :func:`.backref` on :func:`.relationship`.
+
+    .. change::
         :tags: bug, postgresql
         :tickets: 3587
 

--- a/lib/sqlalchemy/ext/declarative/clsregistry.py
+++ b/lib/sqlalchemy/ext/declarative/clsregistry.py
@@ -321,7 +321,8 @@ def _deferred_relationship(cls, prop):
             key, kwargs = prop.backref
             for attr in ('primaryjoin', 'secondaryjoin', 'secondary',
                          'foreign_keys', 'remote_side', 'order_by'):
-                if attr in kwargs and isinstance(kwargs[attr], str):
+                if attr in kwargs and isinstance(kwargs[attr],
+                                                 util.string_types):
                     kwargs[attr] = resolve_arg(kwargs[attr])
 
     return prop

--- a/test/ext/declarative/test_basic.py
+++ b/test/ext/declarative/test_basic.py
@@ -102,6 +102,29 @@ class DeclarativeTest(DeclarativeTestBase):
 
         assert User.addresses.property.mapper.class_ is Address
 
+    def test_unicode_string_resolve_backref(self):
+        class User(Base, fixtures.ComparableEntity):
+            __tablename__ = 'users'
+
+            id = Column('id', Integer, primary_key=True,
+                        test_needs_autoincrement=True)
+            name = Column('name', String(50))
+
+        class Address(Base, fixtures.ComparableEntity):
+            __tablename__ = 'addresses'
+
+            id = Column(Integer, primary_key=True,
+                        test_needs_autoincrement=True)
+            email = Column(String(50), key='_email')
+            user_id = Column('user_id', Integer, ForeignKey('users.id'),
+                             key='_user_id')
+            user = relationship(
+                    User,
+                    backref=backref("addresses",
+                                    order_by=util.u("Address.email")))
+
+        assert Address.user.property.mapper.class_ is User
+
     def test_no_table(self):
         def go():
             class User(Base):


### PR DESCRIPTION
Fixed bug where in Py2K a unicode literal would not be accepted as the
string name of a class or other argument within declarative using
:func:`.backref` on :func:`.relationship`.

amends commit e6f67f48054d906856f879bc1803ea639aa4b670