### PR TITLE
Pass precision value to mssql.DATETIME2 when it is 0

### DIFF
--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -773,7 +773,7 @@ class MSTypeCompiler(compiler.GenericTypeCompiler):
 
     def visit_DATETIME2(self, type_, **kw):
         precision = getattr(type_, 'precision', None)
-        if precision:
+        if precision is not None:
             return "DATETIME2(%s)" % precision
         else:
             return "DATETIME2"

--- a/test/dialect/mssql/test_types.py
+++ b/test/dialect/mssql/test_types.py
@@ -464,6 +464,8 @@ class TypeRoundTripTest(
 
             (mssql.MSDateTime2, [], {},
              'DATETIME2', ['>=', (10,)]),
+            (mssql.MSDateTime2, [0], {},
+             'DATETIME2(0)', ['>=', (10,)]),
             (mssql.MSDateTime2, [1], {},
              'DATETIME2(1)', ['>=', (10,)]),
 


### PR DESCRIPTION
The simple check on the precision results in DATETIME2(0) generating a
DATETIME2 column, with default precision, which is 7.

