### PR TITLE
fix postgresql exclude contraint has when= check

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/ext.py
+++ b/lib/sqlalchemy/dialects/postgresql/ext.py
@@ -142,7 +142,7 @@ static/sql-createtable.html#SQL-CREATETABLE-EXCLUDE
         )
         self.using = kw.get('using', 'gist')
         where = kw.get('where')
-        if where:
+        if where is not None:
             self.where = expression._literal_as_text(where)
 
     def copy(self, **kw):

--- a/test/dialect/postgresql/test_compiler.py
+++ b/test/dialect/postgresql/test_compiler.py
@@ -510,6 +510,19 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             '(CAST("Room" AS TEXT) WITH =)'
         )
 
+    def test_exclude_constraint_when(self):
+        m = MetaData()
+        tbl = Table(
+            'testtbl', m,
+            Column('room', String)
+        )
+        cons = ExcludeConstraint(('room', '='), where=tbl.c.room.in_(['12']))
+        tbl.append_constraint(cons)
+        self.assert_compile(schema.AddConstraint(cons),
+                            'ALTER TABLE testtbl ADD EXCLUDE USING gist '
+                            '(room WITH =) WHERE (testtbl.room IN (\'12\'))',
+                            dialect=postgresql.dialect())
+
     def test_substring(self):
         self.assert_compile(func.substring('abc', 1, 2),
                             'SUBSTRING(%(substring_1)s FROM %(substring_2)s '


### PR DESCRIPTION
currently just does `__bool__` eval, which for me causes e.g.:

```
Traceback (most recent call last):
  File "/home/ai/code/sqlalchemy/test/dialect/postgresql/test_compiler.py", line 519, in test_exclude_constraint_when
    cons = ExcludeConstraint(('room', '='), where=tbl.c.room.in_(['12']))
  File "/home/ai/code/sqlalchemy/test/../lib/sqlalchemy/dialects/postgresql/ext.py", line 145, in __init__
    if where:
  File "/home/ai/code/sqlalchemy/test/../lib/sqlalchemy/sql/elements.py", line 2873, in __bool__
    raise TypeError("Boolean value of this clause is not defined")
TypeError: Boolean value of this clause is not defined
```

checking `is not None`  fixed it.
