### PR TITLE
Fix a typo in the disconnect handling code example

### DIFF
--- a/doc/build/core/pooling.rst
+++ b/doc/build/core/pooling.rst
@@ -257,7 +257,7 @@ best way to do this is to make use of the
             # run a SELECT 1.   use a core select() so that
             # the SELECT of a scalar value without a table is
             # appropriately formatted for the backend
-            connection.scalar(select[1])
+            connection.scalar(select([1]))
         except exc.DBAPIError as err:
             # catch SQLAlchemy's DBAPIError, which is a wrapper
             # for the DBAPI's exception.  It includes a .connection_invalidated


### PR DESCRIPTION
I used this example in my project and ran into an error

    TypeError: 'function' object has no attribute '__getitem__'

I assume it's meant to be like line 272.