### PR TITLE
Fix _assert_unorderable_types on py36.

### DIFF
--- a/lib/sqlalchemy/util/__init__.py
+++ b/lib/sqlalchemy/util/__init__.py
@@ -6,7 +6,7 @@
 # the MIT License: http://www.opensource.org/licenses/mit-license.php
 
 from .compat import callable, cmp, reduce,  \
-    threading, py3k, py33, py2k, jython, pypy, cpython, win32, \
+    threading, py3k, py33, py36, py2k, jython, pypy, cpython, win32, \
     pickle, dottedgetter, parse_qsl, namedtuple, next, reraise, \
     raise_from_cause, text_type, safe_kwarg, string_types, int_types, \
     binary_type, nested, \

--- a/lib/sqlalchemy/util/compat.py
+++ b/lib/sqlalchemy/util/compat.py
@@ -14,6 +14,7 @@ try:
 except ImportError:
     import dummy_threading as threading
 
+py36 = sys.version_info >= (3, 6)
 py33 = sys.version_info >= (3, 3)
 py32 = sys.version_info >= (3, 2)
 py3k = sys.version_info >= (3, 0)

--- a/test/base/test_utils.py
+++ b/test/base/test_utils.py
@@ -1200,7 +1200,10 @@ class IdentitySetTest(fixtures.TestBase):
         return super_, sub_, twin1, twin2, unique1, unique2
 
     def _assert_unorderable_types(self, callable_):
-        if util.py3k:
+        if util.py36:
+            assert_raises_message(
+                TypeError, 'not supported between instances of', callable_)
+        elif util.py3k:
             assert_raises_message(
                 TypeError, 'unorderable types', callable_)
         else:


### PR DESCRIPTION
The error message changed to:

`'<' not supported between instances of 'foo' and 'bar'`

See https://bitbucket.org/zzzeek/sqlalchemy/pull-requests/67/

https://github.com/python/cpython/commit/9d2ff5ed5d9121982ad1057df599f1073ae65569