### PR TITLE
Add new reserved words for MySQL 5.7.

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -602,6 +602,8 @@ RESERVED_WORDS = set(
      'get', 'io_after_gtids', 'io_before_gtids', 'master_bind', 'one_shot',
         'partition', 'sql_after_gtids', 'sql_before_gtids',  # 5.6
 
+     'generated', 'optimizer_costs', 'stored', 'virtual',  # 5.7
+
      ])
 
 AUTOCOMMIT_RE = re.compile(


### PR DESCRIPTION
MySQL 5.7 adds many new keywords but only four new reserved words according to https://dev.mysql.com/doc/refman/5.7/en/keywords.html#table-keywords-new-5.7