### PR TITLE
Fix executemany syntax in core tutorial.

### DIFF
--- a/doc/build/core/tutorial.rst
+++ b/doc/build/core/tutorial.rst
@@ -345,12 +345,12 @@ inserted, as we do here to add some email addresses:
 .. sourcecode:: pycon+sql
 
     >>> conn.execute(addresses.insert(), [
-    ...    {'user_id': 1, 'email_address' : 'jack@yahoo.com'},
-    ...    {'user_id': 1, 'email_address' : 'jack@msn.com'},
-    ...    {'user_id': 2, 'email_address' : 'www@www.org'},
-    ...    {'user_id': 2, 'email_address' : 'wendy@aol.com'},
+    ...    {'user_id': 1, 'email_addresses' : 'jack@yahoo.com'},
+    ...    {'user_id': 1, 'email_addresses' : 'jack@msn.com'},
+    ...    {'user_id': 2, 'email_addresses' : 'www@www.org'},
+    ...    {'user_id': 2, 'email_addresses' : 'wendy@aol.com'},
     ... ])
-    {opensql}INSERT INTO addresses (user_id, email_address) VALUES (?, ?)
+    {opensql}INSERT INTO addresses (user_id, email_addresses) VALUES (?, ?)
     ((1, 'jack@yahoo.com'), (1, 'jack@msn.com'), (2, 'www@www.org'), (2, 'wendy@aol.com'))
     COMMIT
     {stop}<sqlalchemy.engine.result.ResultProxy object at 0x...>


### PR DESCRIPTION
When following through the tutorial, I ran into this error:

    >>> conn.execute(addresses.insert(), [
    ...     {'user_id': 1, 'email_address': "jack@yahoo.com"},
    ...     {'user_id': 1, 'email_address': "jack@msn.com"},
    ...     {'user_id': 2, 'email_address': "www@www.org"},
    ...     {'user_id': 2, 'email_address': "wendy@aol.com"},
    ... ])
    2015-12-16 10:44:02,828 INFO sqlalchemy.engine.base.Engine INSERT INTO addresses (user_id) VALUES (?)
    INFO:sqlalchemy.engine.base.Engine:INSERT INTO addresses (user_id) VALUES (?)
    2015-12-16 10:44:02,828 INFO sqlalchemy.engine.base.Engine ((1,), (1,), (2,), (2,))
    INFO:sqlalchemy.engine.base.Engine:((1,), (1,), (2,), (2,))
    2015-12-16 10:44:02,828 INFO sqlalchemy.engine.base.Engine ROLLBACK
    INFO:sqlalchemy.engine.base.Engine:ROLLBACK
    Traceback (most recent call last):
      File "<console>", line 5, in <module>
      File "/XXX/build/venv/lib/python2.6/site-packages/sqlalchemy/engine/base.py", line 914, in execute
        return meth(self, multiparams, params)
      File "/XXX/build/venv/lib/python2.6/site-packages/sqlalchemy/sql/elements.py", line 323, in _execute_on_connection
        return connection._execute_clauseelement(self, multiparams, params)
      File "/XXX/build/venv/lib/python2.6/site-packages/sqlalchemy/engine/base.py", line 1010, in _execute_clauseelement
        compiled_sql, distilled_params
      File "/XXX/build/venv/lib/python2.6/site-packages/sqlalchemy/engine/base.py", line 1146, in _execute_context
        context)
      File "/XXX/build/venv/lib/python2.6/site-packages/sqlalchemy/engine/base.py", line 1341, in _handle_dbapi_exception
        exc_info
      File "/XXX/build/venv/lib/python2.6/site-packages/sqlalchemy/util/compat.py", line 199, in raise_from_cause
        reraise(type(exception), exception, tb=exc_tb)
      File "/XXX/build/venv/lib/python2.6/site-packages/sqlalchemy/engine/base.py", line 1116, in _execute_context
        context)
      File "/XXX/build/venv/lib/python2.6/site-packages/sqlalchemy/engine/default.py", line 447, in do_executemany
        cursor.executemany(statement, parameters)
    IntegrityError: (sqlite3.IntegrityError) NOT NULL constraint failed: addresses.email_addresses [SQL: u'INSERT INTO addresses (user_id) VALUES (?)'] [parameters: ((1,), (1,), (2,), (2,))]

However, this appears to work:

    >>> conn.execute(addresses.insert(), [
    ...     {'user_id': 1, 'email_addresses' : 'jack@yahoo.com'},
    ...     {'user_id': 1, 'email_addresses' : 'jack@msn.com'},
    ...     {'user_id': 2, 'email_addresses' : 'www@www.org'},
    ...     {'user_id': 2, 'email_addresses' : 'wendy@aol.com'},
    ... ])
    2015-12-16 10:44:39,703 INFO sqlalchemy.engine.base.Engine INSERT INTO addresses (user_id, email_addresses) VALUES (?, ?)
    INFO:sqlalchemy.engine.base.Engine:INSERT INTO addresses (user_id, email_addresses) VALUES (?, ?)
    2015-12-16 10:44:39,704 INFO sqlalchemy.engine.base.Engine ((1, 'jack@yahoo.com'), (1, 'jack@msn.com'), (2, 'www@www.org'), (2, 'wendy@aol.com'))
    INFO:sqlalchemy.engine.base.Engine:((1, 'jack@yahoo.com'), (1, 'jack@msn.com'), (2, 'www@www.org'), (2, 'wendy@aol.com'))
    2015-12-16 10:44:39,704 INFO sqlalchemy.engine.base.Engine COMMIT
    INFO:sqlalchemy.engine.base.Engine:COMMIT
    <sqlalchemy.engine.result.ResultProxy object at 0x10bdb8590>
    >>> 