### PR TITLE
Fix ArrayOfEnum's handling of empty arrays.

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -579,7 +579,7 @@ use the following workaround type::
 
             def handle_raw_string(value):
                 inner = re.match(r"^{(.*)}$", value).group(1)
-                return inner.split(",")
+                return inner.split(",") if inner else []
 
             def process(value):
                 if value is None:


### PR DESCRIPTION
Prior to this change a value of `'{}'` would split into the list `['']`, which is doubly surprising because it was supposed to be an empty list and the value `''` isn't a valid member of the enum.

Also note this code is in a comment, it does appear to be working for me after this change though.