### PR TITLE
sqlite: reflect primary key constraint names

### DIFF
--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -1297,12 +1297,12 @@ class SQLiteDialect(default.DefaultDialect):
 
     @reflection.cache
     def get_pk_constraint(self, connection, table_name, schema=None, **kw):
+        constraint_name = None
         table_data = self._get_table_sql(connection, table_name, schema=schema)
-
-        def parse_pk():
+        if table_data:
             PK_PATTERN = 'CONSTRAINT (\w+) PRIMARY KEY'
             result = re.search(PK_PATTERN, table_data, re.I)
-            return result.group(1) if result else None
+            constraint_name = result.group(1) if result else None
 
         cols = self.get_columns(connection, table_name, schema, **kw)
         pkeys = []
@@ -1310,7 +1310,6 @@ class SQLiteDialect(default.DefaultDialect):
             if col['primary_key']:
                 pkeys.append(col['name'])
 
-        constraint_name = parse_pk() if table_data else None
         return {'constrained_columns': pkeys, 'name': constraint_name}
 
     @reflection.cache

--- a/test/requirements.py
+++ b/test/requirements.py
@@ -528,7 +528,7 @@ class DefaultRequirements(SuiteRequirements):
         """Target driver reflects the name of primary key constraints."""
 
         return fails_on_everything_except('postgresql', 'oracle', 'mssql',
-                    'sybase')
+                    'sybase', 'sqlite')
 
     @property
     def json_type(self):


### PR DESCRIPTION
Pull request for issue [#3629 - SQLite reflection does not preserve primary key constraint names](https://bitbucket.org/zzzeek/sqlalchemy/issues/3629)

Let me know if you want it changed in any way. Thanks!
