### PR TITLE
The AutomapBase's prepare method now accepts an optional schema argument to pass to reflect

### DIFF
--- a/lib/sqlalchemy/ext/automap.py
+++ b/lib/sqlalchemy/ext/automap.py
@@ -695,6 +695,7 @@ class AutomapBase(object):
             cls,
             engine=None,
             reflect=False,
+            schema=None,
             classname_for_table=classname_for_table,
             collection_class=list,
             name_for_scalar_relationship=name_for_scalar_relationship,
@@ -739,6 +740,7 @@ class AutomapBase(object):
         if reflect:
             cls.metadata.reflect(
                 engine,
+                schema=schema,
                 extend_existing=True,
                 autoload_replace=False
             )


### PR DESCRIPTION
I've encountered an issue using `auto_map` to build my models when tables are not in the `public` schema.  This alleviates the issue by allowing the `prepare` method to accept an optional `schema` argument, which is then passed to the underlying `cls.metadata.reflect` call.