### PR TITLE
Reduce number of insert stmts for bulk inserts with None values

### DIFF
--- a/lib/sqlalchemy/orm/persistence.py
+++ b/lib/sqlalchemy/orm/persistence.py
@@ -25,7 +25,8 @@ from . import loading
 
 
 def _bulk_insert(
-        mapper, mappings, session_transaction, isstates, return_defaults):
+        mapper, mappings, session_transaction, isstates, return_defaults,
+        with_none):
     base_mapper = mapper.base_mapper
 
     cached_connections = _cached_connection_dict(base_mapper)
@@ -58,7 +59,7 @@ def _bulk_insert(
             has_all_defaults in _collect_insert_commands(table, (
                 (None, mapping, mapper, connection)
                 for mapping in mappings),
-                bulk=True, return_defaults=return_defaults
+                bulk=True, return_defaults=return_defaults, with_none=with_none
             )
         )
         _emit_insert_statements(base_mapper, None,
@@ -363,7 +364,7 @@ def _organize_states_for_delete(base_mapper, states, uowtransaction):
 
 def _collect_insert_commands(
         table, states_to_insert,
-        bulk=False, return_defaults=False):
+        bulk=False, return_defaults=False, with_none=False):
     """Identify sets of values to use in INSERT statements for a
     list of states.
 
@@ -382,7 +383,7 @@ def _collect_insert_commands(
         for propkey in set(propkey_to_col).intersection(state_dict):
             value = state_dict[propkey]
             col = propkey_to_col[propkey]
-            if value is None and propkey not in eval_none:
+            if value is None and propkey not in eval_none and not with_none:
                 continue
             elif not bulk and isinstance(value, sql.ClauseElement):
                 value_params[col.key] = value

--- a/lib/sqlalchemy/orm/session.py
+++ b/lib/sqlalchemy/orm/session.py
@@ -2235,9 +2235,10 @@ class Session(_SessionClassMethods):
         ):
             self._bulk_save_mappings(
                 mapper, states, isupdate, True,
-                return_defaults, update_changed_only)
+                return_defaults, update_changed_only, False)
 
-    def bulk_insert_mappings(self, mapper, mappings, return_defaults=False):
+    def bulk_insert_mappings(
+            self, mapper, mappings, return_defaults=False, with_none=False):
         """Perform a bulk insert of the given list of mapping dictionaries.
 
         The bulk insert feature allows plain Python dictionaries to be used as
@@ -2290,6 +2291,9 @@ class Session(_SessionClassMethods):
          reason this flag should be set as the returned default information
          is not used.
 
+        :param with_none: when True, `None` values are not omitted which can
+         help in reducing the number of insert statements.
+
 
         .. seealso::
 
@@ -2301,7 +2305,7 @@ class Session(_SessionClassMethods):
 
         """
         self._bulk_save_mappings(
-            mapper, mappings, False, False, return_defaults, False)
+            mapper, mappings, False, False, return_defaults, False, with_none)
 
     def bulk_update_mappings(self, mapper, mappings):
         """Perform a bulk update of the given list of mapping dictionaries.
@@ -2350,11 +2354,12 @@ class Session(_SessionClassMethods):
             :meth:`.Session.bulk_save_objects`
 
         """
-        self._bulk_save_mappings(mapper, mappings, True, False, False, False)
+        self._bulk_save_mappings(
+            mapper, mappings, True, False, False, False, False)
 
     def _bulk_save_mappings(
             self, mapper, mappings, isupdate, isstates,
-            return_defaults, update_changed_only):
+            return_defaults, update_changed_only, with_none):
         mapper = _class_to_mapper(mapper)
         self._flushing = True
 
@@ -2367,7 +2372,8 @@ class Session(_SessionClassMethods):
                     isstates, update_changed_only)
             else:
                 persistence._bulk_insert(
-                    mapper, mappings, transaction, isstates, return_defaults)
+                    mapper, mappings, transaction,
+                    isstates, return_defaults, with_none)
             transaction.commit()
 
         except:

--- a/test/orm/test_bulk.py
+++ b/test/orm/test_bulk.py
@@ -17,11 +17,12 @@ class BulkInsertUpdateTest(BulkTest, _fixtures.FixtureTest):
 
     @classmethod
     def setup_mappers(cls):
-        User, Address = cls.classes("User", "Address")
-        u, a = cls.tables("users", "addresses")
+        User, Address, Order = cls.classes("User", "Address", "Order")
+        u, a, o = cls.tables("users", "addresses", "orders")
 
         mapper(User, u)
         mapper(Address, a)
+        mapper(Order, o)
 
     def test_bulk_save_return_defaults(self):
         User, = self.classes("User",)
@@ -152,6 +153,28 @@ class BulkInsertUpdateTest(BulkTest, _fixtures.FixtureTest):
                 [{'id': 1, 'name': 'u1new'},
                  {'id': 2, 'name': 'u2'},
                  {'id': 3, 'name': 'u3new'}]
+            )
+        )
+
+    def test_bulk_insert_with_none(self):
+        Order, = self.classes("Order",)
+
+        s = Session()
+        with self.sql_execution_asserter() as asserter:
+            s.bulk_insert_mappings(
+                Order,
+                [{'id': 1, 'description': 'u1new'},
+                 {'id': 2, 'description': None},
+                 {'id': 3, 'description': 'u3new'}],
+                with_none=True
+            )
+
+        asserter.assert_(
+            CompiledSQL(
+                "INSERT INTO orders (id, description) VALUES (:id, :description)",
+                [{'id': 1, 'description': 'u1new'},
+                 {'id': 2, 'description': None},
+                 {'id': 3, 'description': 'u3new'}]
             )
         )
 


### PR DESCRIPTION
Currently, when using `Session.bulk_insert_mappings` multiple insert statements might get issued when dictionaries contain `None` values. For example:

    session.bulk_insert_mappings(Doc, [
        dict(id=1, col_a='A', col_b='B'),
        dict(id=2, col_a='A', col_b=None),
        dict(id=3, col_a='A', col_b='B')
    ])

This call makes three insert statements instead of a single one as I would expect:

    2016-01-06 21:35:58,033 INFO sqlalchemy.engine.base.Engine INSERT INTO doc (id, col_a, col_b) VALUES (?, ?, ?)
    2016-01-06 21:35:58,033 INFO sqlalchemy.engine.base.Engine (1, 'A', 'B')
    2016-01-06 21:35:58,034 INFO sqlalchemy.engine.base.Engine INSERT INTO doc (id, col_a) VALUES (?, ?)
    2016-01-06 21:35:58,034 INFO sqlalchemy.engine.base.Engine (2, 'A')
    2016-01-06 21:35:58,034 INFO sqlalchemy.engine.base.Engine INSERT INTO doc (id, col_a, col_b) VALUES (?, ?, ?)
    2016-01-06 21:35:58,034 INFO sqlalchemy.engine.base.Engine (3, 'A', 'B')

(I posted this problem a while ago on the [mailing-list](https://groups.google.com/d/msg/sqlalchemy/PuChIeWCdkg/2oCoh9WdAAAJ).)

This PR proposes to add an attribute `with_none` to `Session.bulk_insert_mappings`. When set to `True`, attributes of dictionaries that are set to `None` will not be omitted.

If this PR is going in the right direction, I can also add this attribute to `Session.bulk_update_mappings`.