### PR TITLE
Add IS (NOT) DISTINCT FROM operator

### DIFF
--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -849,6 +849,14 @@ class SQLiteCompiler(compiler.SQLCompiler):
         # sqlite has no "FOR UPDATE" AFAICT
         return ''
 
+    def visit_is_distinct_from_binary(self, binary, operator, **kw):
+        return "%s IS NOT %s" % (self.process(binary.left),
+                                 self.process(binary.right))
+
+    def visit_isnot_distinct_from_binary(self, binary, operator, **kw):
+        return "%s IS %s" % (self.process(binary.left),
+                             self.process(binary.right))
+
 
 class SQLiteDDLCompiler(compiler.DDLCompiler):
 

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -81,6 +81,8 @@ OPERATORS = {
     operators.gt: ' > ',
     operators.ge: ' >= ',
     operators.eq: ' = ',
+    operators.is_distinct_from: ' IS DISTINCT FROM ',
+    operators.isnot_distinct_from: ' IS NOT DISTINCT FROM ',
     operators.concat_op: ' || ',
     operators.match_op: ' MATCH ',
     operators.notmatch_op: ' NOT MATCH ',

--- a/lib/sqlalchemy/sql/default_comparator.py
+++ b/lib/sqlalchemy/sql/default_comparator.py
@@ -32,8 +32,9 @@ def _boolean_compare(expr, op, obj, negate=None, reverse=False,
         # allow x ==/!= True/False to be treated as a literal.
         # this comes out to "== / != true/false" or "1/0" if those
         # constants aren't supported and works on all platforms
-        if op in (operators.eq, operators.ne) and \
-                isinstance(obj, (bool, True_, False_)):
+        if (op in (operators.eq, operators.ne) and \
+                isinstance(obj, (bool, True_, False_))) or \
+                op in (operators.is_distinct_from, operators.isnot_distinct_from):
             return BinaryExpression(expr,
                                     _literal_as_text(obj),
                                     op,
@@ -51,8 +52,9 @@ def _boolean_compare(expr, op, obj, negate=None, reverse=False,
                                         negate=operators.is_)
             else:
                 raise exc.ArgumentError(
-                    "Only '=', '!=', 'is_()', 'isnot()' operators can "
-                    "be used with None/True/False")
+                    "Only '=', '!=', 'is_()', 'isnot()', "
+                    "'is_distinct_from()', 'isnot_distinct_from()' "
+                    "operators can be used with None/True/False")
     else:
         obj = _check_literal(expr, op, obj)
 
@@ -249,6 +251,8 @@ operator_lookup = {
     "gt": (_boolean_compare, operators.le),
     "ge": (_boolean_compare, operators.lt),
     "eq": (_boolean_compare, operators.ne),
+    "is_distinct_from": (_boolean_compare, operators.isnot_distinct_from),
+    "isnot_distinct_from": (_boolean_compare, operators.isnot_distinct_from),
     "like_op": (_boolean_compare, operators.notlike_op),
     "ilike_op": (_boolean_compare, operators.notilike_op),
     "notlike_op": (_boolean_compare, operators.like_op),

--- a/lib/sqlalchemy/sql/default_comparator.py
+++ b/lib/sqlalchemy/sql/default_comparator.py
@@ -252,7 +252,7 @@ operator_lookup = {
     "ge": (_boolean_compare, operators.lt),
     "eq": (_boolean_compare, operators.ne),
     "is_distinct_from": (_boolean_compare, operators.isnot_distinct_from),
-    "isnot_distinct_from": (_boolean_compare, operators.isnot_distinct_from),
+    "isnot_distinct_from": (_boolean_compare, operators.is_distinct_from),
     "like_op": (_boolean_compare, operators.notlike_op),
     "ilike_op": (_boolean_compare, operators.notilike_op),
     "notlike_op": (_boolean_compare, operators.like_op),

--- a/lib/sqlalchemy/sql/operators.py
+++ b/lib/sqlalchemy/sql/operators.py
@@ -314,7 +314,8 @@ class ColumnOperators(Operators):
     def is_distinct_from(self, other):
         """Implement the ``IS DISTINCT FROM`` operator.
 
-
+        On databases where the ``IS`` operator supplies the
+        same functionality, e.g. sqlite, produces ``IS NOT``.
 
         """
         return self.operate(is_distinct_from, other)
@@ -322,7 +323,8 @@ class ColumnOperators(Operators):
     def isnot_distinct_from(self, other):
         """Implement the ``IS NOT DISTINCT FROM`` operator.
 
-
+        On databases where the ``IS`` operator supplies the
+        same functionality, e.g. sqlite, produces ``IS``.
 
         """
         return self.operate(isnot_distinct_from, other)

--- a/lib/sqlalchemy/sql/operators.py
+++ b/lib/sqlalchemy/sql/operators.py
@@ -311,6 +311,22 @@ class ColumnOperators(Operators):
         """
         return self.operate(ne, other)
 
+    def is_distinct_from(self, other):
+        """Implement the ``IS DISTINCT FROM`` operator.
+
+
+
+        """
+        return self.operate(is_distinct_from, other)
+
+    def isnot_distinct_from(self, other):
+        """Implement the ``IS NOT DISTINCT FROM`` operator.
+
+
+
+        """
+        return self.operate(isnot_distinct_from, other)
+
     def __gt__(self, other):
         """Implement the ``>`` operator.
 
@@ -722,6 +738,15 @@ def istrue(a):
 def isfalse(a):
     raise NotImplementedError()
 
+
+def is_distinct_from(a, b):
+    return a.is_distinct_from(b)
+
+
+def isnot_distinct_from(a, b):
+    return a.isnot_distinct_from(b)
+
+
 def is_(a, b):
     return a.is_(b)
 
@@ -931,6 +956,8 @@ _PRECEDENCE = {
 
     eq: 5,
     ne: 5,
+    is_distinct_from: 5,
+    isnot_distinct_from: 5,
     gt: 5,
     lt: 5,
     ge: 5,

--- a/test/sql/test_operators.py
+++ b/test/sql/test_operators.py
@@ -99,6 +99,18 @@ class DefaultColumnComparatorTest(fixtures.TestBase):
     def test_notequals_true(self):
         self._do_operate_test(operators.ne, True)
 
+    def test_is_distinct_from_true(self):
+        self._do_operate_test(operators.is_distinct_from, True)
+
+    def test_is_distinct_from_false(self):
+        self._do_operate_test(operators.is_distinct_from, False)
+
+    def test_is_distinct_from_null(self):
+        self._do_operate_test(operators.is_distinct_from, None)
+
+    def test_isnot_distinct_from_true(self):
+        self._do_operate_test(operators.isnot_distinct_from, True)
+
     def test_is_true(self):
         self._do_operate_test(operators.is_, True)
 

--- a/test/sql/test_operators.py
+++ b/test/sql/test_operators.py
@@ -1539,6 +1539,50 @@ class OperatorAssociativityTest(fixtures.TestBase, testing.AssertsCompiledSQL):
         self.assert_compile(f / (f / (f - f)), "f / (f / (f - f))")
 
 
+class IsDistinctFromTest(fixtures.TestBase, testing.AssertsCompiledSQL):
+    __dialect__ = 'default'
+
+    table1 = table('mytable',
+                   column('myid', Integer),
+                   )
+
+    def test_is_distinct_from(self):
+        self.assert_compile(self.table1.c.myid.is_distinct_from(1),
+                            "mytable.myid IS DISTINCT FROM :myid_1")
+
+    def test_is_distinct_from_postgresql(self):
+        self.assert_compile(self.table1.c.myid.is_distinct_from(1),
+                            "mytable.myid IS DISTINCT FROM %(myid_1)s",
+                            dialect=postgresql.dialect())
+
+    def test_not_is_distinct_from(self):
+        self.assert_compile(~self.table1.c.myid.is_distinct_from(1),
+                            "mytable.myid IS NOT DISTINCT FROM :myid_1")
+
+    def test_not_is_distinct_from_postgresql(self):
+        self.assert_compile(~self.table1.c.myid.is_distinct_from(1),
+                            "mytable.myid IS NOT DISTINCT FROM %(myid_1)s",
+                            dialect=postgresql.dialect())
+
+    def test_isnot_distinct_from(self):
+        self.assert_compile(self.table1.c.myid.isnot_distinct_from(1),
+                            "mytable.myid IS NOT DISTINCT FROM :myid_1")
+
+    def test_isnot_distinct_from_postgresql(self):
+        self.assert_compile(self.table1.c.myid.isnot_distinct_from(1),
+                            "mytable.myid IS NOT DISTINCT FROM %(myid_1)s",
+                            dialect=postgresql.dialect())
+
+    def test_not_isnot_distinct_from(self):
+        self.assert_compile(~self.table1.c.myid.isnot_distinct_from(1),
+                            "mytable.myid IS DISTINCT FROM :myid_1")
+
+    def test_not_isnot_distinct_from_postgresql(self):
+        self.assert_compile(~self.table1.c.myid.isnot_distinct_from(1),
+                            "mytable.myid IS DISTINCT FROM %(myid_1)s",
+                            dialect=postgresql.dialect())
+
+
 class InTest(fixtures.TestBase, testing.AssertsCompiledSQL):
     __dialect__ = 'default'
 

--- a/test/sql/test_operators.py
+++ b/test/sql/test_operators.py
@@ -1550,6 +1550,11 @@ class IsDistinctFromTest(fixtures.TestBase, testing.AssertsCompiledSQL):
         self.assert_compile(self.table1.c.myid.is_distinct_from(1),
                             "mytable.myid IS DISTINCT FROM :myid_1")
 
+    def test_is_distinct_from_sqlite(self):
+        self.assert_compile(self.table1.c.myid.is_distinct_from(1),
+                            "mytable.myid IS NOT ?",
+                            dialect=sqlite.dialect())
+
     def test_is_distinct_from_postgresql(self):
         self.assert_compile(self.table1.c.myid.is_distinct_from(1),
                             "mytable.myid IS DISTINCT FROM %(myid_1)s",
@@ -1567,6 +1572,11 @@ class IsDistinctFromTest(fixtures.TestBase, testing.AssertsCompiledSQL):
     def test_isnot_distinct_from(self):
         self.assert_compile(self.table1.c.myid.isnot_distinct_from(1),
                             "mytable.myid IS NOT DISTINCT FROM :myid_1")
+
+    def test_isnot_distinct_from_sqlite(self):
+        self.assert_compile(self.table1.c.myid.isnot_distinct_from(1),
+                            "mytable.myid IS ?",
+                            dialect=sqlite.dialect())
 
     def test_isnot_distinct_from_postgresql(self):
         self.assert_compile(self.table1.c.myid.isnot_distinct_from(1),


### PR DESCRIPTION
`None` and bools rendered as literal (`IS DISTINCT FROM NULL/true/false`)

The sqlite dialect could render the operator(s) as `IS NOT ...`: SQLite lacks `IS DISTINCT FROM` but accepts non-booleans in `IS (NOT)`.