### PR TITLE
Extend view reflection in PostgreSQL to support differentiating between normal views and materialized views

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -1933,13 +1933,16 @@ class PGDialect(default.DefaultDialect):
 
     @reflection.cache
     def get_view_names(self, connection, schema=None, include=('plain', 'materialized'), **kw):
-        include_kinds = {'plain': 'v', 'materialized': 'm'}
+        include_kind = {'plain': 'v', 'materialized': 'm'}
         try:
-            kinds = tuple(include_kinds[i] for i in include) or (None,)
+            kinds = tuple(include_kind[i] for i in include)
         except KeyError:
-            raise ValueError("include %r unknown, needs to be a tuple containing "
+            raise ValueError("include %r unknown, needs to be a sequence containing "
                              "one or both of 'plain' and 'materialized'" % (include,))
-            
+        if not kinds:
+            raise ValueError("empty include, needs to be a sequence containing "
+                             "one or both of 'plain' and 'materialized'")
+
         result = connection.execute(
             sql.text("SELECT c.relname FROM pg_class c "
                      "JOIN pg_namespace n ON n.oid = c.relnamespace "

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -1933,15 +1933,9 @@ class PGDialect(default.DefaultDialect):
 
     @reflection.cache
     def get_view_names(self, connection, schema=None, include=('plain', 'materialized'), **kw):
-        include_kinds = {
-            ('plain', 'materialized'): ('v', 'm'),
-            ('materialized', 'plain'): ('v', 'm'),
-            ('plain',): ('v,',),
-            ('materialized',): ('m',),
-            (): (None,)
-        }
+        include_kinds = {'plain': 'v', 'materialized': 'm'}
         try:
-            kinds = include_kinds[include]
+            kinds = tuple(include_kinds[i] for i in include) or (None,)
         except KeyError:
             raise ValueError("include %r unknown, needs to be a tuple containing "
                              "one or both of 'plain' and 'materialized'" % (include,))

--- a/lib/sqlalchemy/engine/reflection.py
+++ b/lib/sqlalchemy/engine/reflection.py
@@ -312,7 +312,7 @@ class Inspector(object):
                 info_cache=self.info_cache, **kw)
         return {}
 
-    def get_view_names(self, schema=None):
+    def get_view_names(self, schema=None, **kw):
         """Return all view names in `schema`.
 
         :param schema: Optional, retrieve names from a non-default schema.
@@ -321,7 +321,7 @@ class Inspector(object):
         """
 
         return self.dialect.get_view_names(self.bind, schema,
-                                           info_cache=self.info_cache)
+                                           info_cache=self.info_cache, **kw)
 
     def get_view_definition(self, view_name, schema=None):
         """Return definition for `view_name`.

--- a/test/dialect/postgresql/test_reflection.py
+++ b/test/dialect/postgresql/test_reflection.py
@@ -129,7 +129,19 @@ class MaterializedViewReflectionTest(
 
     def test_get_view_names(self):
         insp = inspect(testing.db)
-        eq_(set(insp.get_view_names()), set(['test_mview', 'test_regview']))
+        eq_(set(insp.get_view_names()), set(['test_regview', 'test_mview']))
+
+    def test_get_view_names_plain(self):
+        insp = inspect(testing.db)
+        eq_(set(insp.get_view_names(include=('plain',))), set(['test_regview']))
+
+    def test_get_view_names_materialized(self):
+        insp = inspect(testing.db)
+        eq_(set(insp.get_view_names(include=('materialized',))), set(['test_mview']))
+
+    def test_get_view_names_empty(self):
+        insp = inspect(testing.db)
+        eq_(set(insp.get_view_names(include=())), set([]))
 
     def test_get_view_definition(self):
         insp = inspect(testing.db)

--- a/test/dialect/postgresql/test_reflection.py
+++ b/test/dialect/postgresql/test_reflection.py
@@ -141,7 +141,7 @@ class MaterializedViewReflectionTest(
 
     def test_get_view_names_empty(self):
         insp = inspect(testing.db)
-        eq_(set(insp.get_view_names(include=())), set([]))
+        assert_raises(ValueError, insp.get_view_names, include=())
 
     def test_get_view_definition(self):
         insp = inspect(testing.db)


### PR DESCRIPTION
[bb_issue_3588](https://bitbucket.org/zzzeek/sqlalchemy/issues/3588) mentions adding the new `include`-argument of `get_view_names` to the other dialects: not sure about that (isn't reflection somewhat inherently db-specific?)

I took the opportunity to make some related reflection methods cleaner (at least for my taste): pick as you like (if wanted, I could offer some more of that kind of refactoring).