### PR TITLE
ReST fix: missing backtick

### DIFF
--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -255,7 +255,7 @@ render::
     name VARCHAR(20)
 
 If ``nullable`` is ``True`` or ``False`` then the column will be
-``NULL` or ``NOT NULL`` respectively.
+``NULL`` or ``NOT NULL`` respectively.
 
 Date / Time Handling
 --------------------


### PR DESCRIPTION
Fixes a misrendering at http://docs.sqlalchemy.org/en/latest/dialects/mssql.html#nullability:
![ekrano nuotrauka is 2016-03-21 12-01-40](https://cloud.githubusercontent.com/assets/159967/13915340/b5ce016a-ef5c-11e5-9f1a-e2af39303628.png)
