### PR TITLE
Allow creating explicit non-clustered primary keys in MS SQL.

### DIFF
--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -386,7 +386,26 @@ Similarly, we can generate a clustered unique constraint using::
           UniqueConstraint("y", mssql_clustered=True),
           )
 
-  .. versionadded:: 0.9.2
+.. versionadded:: 0.9.2
+
+To explicitly request a non-clustered primary key (for example, when
+a separate clustered index is desired), use::
+
+    Table('my_table', metadata,
+          Column('x', ...),
+          Column('y', ...),
+          PrimaryKeyConstraint("x", "y", mssql_clustered=False))
+
+which will render the table, for example, as::
+
+  CREATE TABLE my_table (x INTEGER NOT NULL, y INTEGER NOT NULL,
+                         PRIMARY KEY NONCLUSTERED (x, y))
+
+.. versionchanged:: 1.1 the ``mssql_clustered`` option used to default to
+   False, now it defaults to None. ``mssql_clustered=False`` now explicitly
+   requests a non-clustered primary key and None relies on default SQL Server
+   behavior.
+
 
 MSSQL-Specific Index Options
 -----------------------------
@@ -1460,8 +1479,12 @@ class MSDDLCompiler(compiler.DDLCompiler):
                     self.preparer.format_constraint(constraint)
         text += "PRIMARY KEY "
 
-        if constraint.dialect_options['mssql']['clustered']:
-            text += "CLUSTERED "
+        clustered = constraint.dialect_options['mssql']['clustered']
+        if clustered is not None:
+            if clustered:
+                text += "CLUSTERED "
+            else:
+                text += "NONCLUSTERED "
 
         text += "(%s)" % ', '.join(self.preparer.quote(c.name)
                                    for c in constraint)
@@ -1572,7 +1595,7 @@ class MSDialect(default.DefaultDialect):
 
     construct_arguments = [
         (sa_schema.PrimaryKeyConstraint, {
-            "clustered": False
+            "clustered": None
         }),
         (sa_schema.UniqueConstraint, {
             "clustered": False

--- a/test/dialect/mssql/test_compiler.py
+++ b/test/dialect/mssql/test_compiler.py
@@ -625,6 +625,18 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             "PRIMARY KEY CLUSTERED (x, y))"
         )
 
+    def test_table_pkc_explicit_nonclustered(self):
+        metadata = MetaData()
+        tbl = Table('test', metadata,
+                    Column('x', Integer, autoincrement=False),
+                    Column('y', Integer, autoincrement=False),
+                    PrimaryKeyConstraint("x", "y", mssql_clustered=False))
+        self.assert_compile(
+            schema.CreateTable(tbl),
+            "CREATE TABLE test (x INTEGER NOT NULL, y INTEGER NOT NULL, "
+            "PRIMARY KEY NONCLUSTERED (x, y))"
+        )
+
     def test_table_uc_clustering(self):
         metadata = MetaData()
         tbl = Table('test', metadata,


### PR DESCRIPTION
TL; DR: Change `mssql_clustered=False` on `PrimaryKeyConstraint` to request a non-clustered primary key and change default to `None`, which uses default behaviour. This is required to have tables with clustered indexes on other than the primary key.

Reasoning:
MS SQL Server default primary key creation (without `CLUSTERED` or `NONCLUSTERED` specified) depends on whether the table already has a clustered index. If a clustered index is present, it will create a non-clustered primary key. Without a clustered index (like when defining a new table), it would create a clustered primary key.

Prior to this patch SQLAlchemy MS SQL dialect didn't allow specifying a non-clustered primary key, so in order to have a clustered index that isn't the primary key, one would have to create a table without a primary key, define a clustered index and then define the primary key. Otherwise MS SQL would create a clustered primary key and index creation would fail.