### PR TITLE
typo: redundant "using the by changing" -> "using the"

### DIFF
--- a/doc/build/orm/cascades.rst
+++ b/doc/build/orm/cascades.rst
@@ -17,7 +17,7 @@ the :ref:`cascade_delete` and :ref:`cascade_delete_orphan` options;
 these settings are appropriate for related objects which only exist as
 long as they are attached to their parent, and are otherwise deleted.
 
-Cascade behavior is configured using the by changing the
+Cascade behavior is configured using the
 :paramref:`~.relationship.cascade` option on
 :func:`~sqlalchemy.orm.relationship`::
 


### PR DESCRIPTION
There seem to be some extra words in this explanation:

> Cascade behavior is configured _using the by changing the_
