### PR TITLE
Mention the correct way of adding multiple attributes

### DIFF
--- a/lib/sqlalchemy/ext/declarative/base.py
+++ b/lib/sqlalchemy/ext/declarative/base.py
@@ -351,7 +351,8 @@ class _MapperConfig(object):
                 util.warn(
                     "On class %r, Column object %r named "
                     "directly multiple times, "
-                    "only one will be used: %s" %
+                    "only one will be used: %s. "
+                    "Consider using orm.synonym instead" %
                     (self.classname, name, (", ".join(sorted(keys))))
                 )
 


### PR DESCRIPTION
This warning confused me as it isn't clear whether something is broken or not.

I did:

    class Timetable(Base):
        timetable_active = Column(Boolean)
       active = timetable_active

When I should have done:

    class Timetable(Base):
        timetable_active = Column(Boolean)
        active = synonym(timetable_active)

But I'm still unsure what the consequences were of doing the former were.