### PR TITLE
Ticket 3529: support for INSERT ... ON CONFLICT in postgresql dialect

### DIFF
--- a/doc/build/dialects/postgresql.rst
+++ b/doc/build/dialects/postgresql.rst
@@ -181,6 +181,15 @@ For example::
           ExcludeConstraint(('room', '='), ('during', '&&')),
       )
 
+PostgreSQL ON CONFLICT Actions
+---------------------------------
+
+.. autoclass:: DoNothing
+   :members: __init__
+
+.. autoclass:: DoUpdate
+   :members: __init__, set_with_excluded
+
 psycopg2
 --------------
 

--- a/lib/sqlalchemy/dialects/postgresql/__init__.py
+++ b/lib/sqlalchemy/dialects/postgresql/__init__.py
@@ -18,6 +18,7 @@ from .hstore import HSTORE, hstore
 from .json import JSON, JSONB
 from .array import array, ARRAY, Any, All
 from .ext import aggregate_order_by, ExcludeConstraint, array_agg
+from .on_conflict import DoNothing, DoUpdate
 
 from .ranges import INT4RANGE, INT8RANGE, NUMRANGE, DATERANGE, TSRANGE, \
     TSTZRANGE

--- a/lib/sqlalchemy/dialects/postgresql/__init__.py
+++ b/lib/sqlalchemy/dialects/postgresql/__init__.py
@@ -31,5 +31,5 @@ __all__ = (
     'hstore', 'INT4RANGE', 'INT8RANGE', 'NUMRANGE', 'DATERANGE',
     'TSRANGE', 'TSTZRANGE', 'json', 'JSON', 'JSONB', 'Any', 'All',
     'DropEnumType', 'CreateEnumType', 'ExcludeConstraint',
-    'aggregate_order_by', 'array_agg'
+    'aggregate_order_by', 'array_agg', 'DoNothing', 'DoUpdate'
 )

--- a/lib/sqlalchemy/dialects/postgresql/array.py
+++ b/lib/sqlalchemy/dialects/postgresql/array.py
@@ -5,7 +5,6 @@
 # This module is part of SQLAlchemy and is released under
 # the MIT License: http://www.opensource.org/licenses/mit-license.php
 
-from .base import ischema_names
 from ...sql import expression, operators
 from ...sql.base import SchemaEventTarget
 from ... import types as sqltypes
@@ -311,4 +310,3 @@ class ARRAY(SchemaEventTarget, sqltypes.ARRAY):
                     tuple if self.as_tuple else list)
         return process
 
-ischema_names['_array'] = ARRAY

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -267,7 +267,7 @@ builders.
 
 Most commonly, ``ON CONFLICT`` is used to perform an update of the already 
 existing row if there is a primary key constraint violated, using the values
-of the row proposed for insert. Use the value `'update'` for the keyword argument::
+of the row proposed for insert. Use the value ``'update'`` for the keyword argument::
 
     table.insert(postgresql_on_conflict='update').\\
         values(key_column='existing_value', other_column='foo')
@@ -279,8 +279,9 @@ columns as the "conflict target" in the ``ON CONFLICT`` clause. This usage
 requires that the targeted table have at least one column participating
 in a :class:`.PrimaryKeyConstraint`.
 
-`ON CONFLICT` is also commonly used to skip inserting a row entirely
-if any conflict occurs. To do this, use the value 'nothing' for the keyword argument::
+``ON CONFLICT`` is also commonly used to skip inserting a row entirely
+if any conflict with a unique or exclusion constraint occurs. 
+To do this, use the value ``'nothing'`` for the keyword argument::
 
     table.insert(postgresql_on_conflict='nothing').\\
         values(key_column='existing_value', other_column='foo')
@@ -295,6 +296,9 @@ to indicate the "conflict target" constraint:
 * a :class:`.PrimaryKeyConstraint`, :class:`.UniqueConstraint`, 
   or :class:`.postgresql.ExcludeConstraint` object representing
   the unique constraint to target.
+* a :class:`.Index` object representing a unique or exclusion
+  constraint on the target table. Useful if you wish to use 
+  a :ref:`partial index <postgresql_partial_indexes>` as your conflict target.
 
 If you use :class:`.postgresql.DoUpdate`, you need to specify which columns on the existing row
 to set with values from the row proposed for insert. Use the
@@ -426,6 +430,8 @@ Postgresql-Specific Index Options
 
 Several extensions to the :class:`.Index` construct are available, specific
 to the PostgreSQL dialect.
+
+.. _postgresql_partial_indexes:
 
 Partial Indexes
 ^^^^^^^^^^^^^^^^

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -264,16 +264,15 @@ to :class:`.Insert`, :meth:`.Table.insert`, and other ``INSERT`` expression
 builders. 
 
 Most commonly, ``ON CONFLICT`` is used to perform an update of the already 
-existing row if there is a primary key constraint violated, using each of the 
-column values provided in the ``VALUES`` clause of the ``INSERT``, except
-for the primary key columns. Use the value `'update'` for the keyword argument:
+existing row if there is a primary key constraint violated, using the values
+of the row proposed for insert. Use the value `'update'` for the keyword argument:
 
     table.insert(postgresql_on_conflict='update').\\
         values(key_column='existing_value', other_column='foo')
 
 and the SQL compiler will produce an ``ON CONFLICT`` clause that performs
 ``DO UPDATE SET...`` for every column value in the ``VALUES`` clause that
-is not a primary key column. The produced SQL will use the primary key
+is not a primary key column for the target table. The produced SQL will use the primary key
 columns as the "conflict target" in the ``ON CONFLICT`` clause. 
 
 `ON CONFLICT` is also commonly used to skip inserting a row entirely
@@ -283,7 +282,8 @@ if a conflict occurs. To do this, use the value 'nothing' for the keyword argume
         values(key_column='existing_value', other_column='foo')
 
 Other, more sophisticated forms of ``ON CONFLICT`` are possible, but they are
-not yet supported by the dialect. For more information, see the
+not yet supported or documented by the dialect. Use text-based statements 
+for more advanced ``ON CONFLICT`` clauses. For more information, see the
 ``ON CONFLICT` section of the `INSERT` statement in the PostgreSQL docs 
 <http://www.postgresql.org/docs/current/static/sql-insert.html#SQL-ON-CONFLICT>`_.
 

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -650,6 +650,7 @@ from ...engine import default, reflection
 from ...sql import compiler, expression, crud
 from ... import types as sqltypes
 from .on_conflict import resolve_on_conflict_option
+from .array import ARRAY
 
 try:
     from uuid import UUID as _python_UUID
@@ -1081,7 +1082,8 @@ ischema_names = {
     'interval': INTERVAL,
     'interval year to month': INTERVAL,
     'interval day to second': INTERVAL,
-    'tsvector': TSVECTOR
+    'tsvector': TSVECTOR,
+    '_array': ARRAY
 }
 
 

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -250,7 +250,7 @@ use the :meth:`._UpdateBase.returning` method on a per-statement basis::
 .. _postgresql_insert_on_conflict:
 
 INSERT...ON CONFLICT (Upsert)
--------------------------
+------------------------------
 
 Starting with version 9.5, PostgreSQL allows "upserts" (update or insert)
 of rows into a table via the ``INSERT`` statement's ``ON CONFLICT`` clause.

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -267,7 +267,7 @@ builders.
 
 Most commonly, ``ON CONFLICT`` is used to perform an update of the already 
 existing row if there is a primary key constraint violated, using the values
-of the row proposed for insert. Use the value `'update'` for the keyword argument:
+of the row proposed for insert. Use the value `'update'` for the keyword argument::
 
     table.insert(postgresql_on_conflict='update').\\
         values(key_column='existing_value', other_column='foo')
@@ -277,17 +277,17 @@ and the SQL compiler will produce an ``ON CONFLICT`` clause that performs
 is not a primary key column for the target table. The produced SQL will use the primary key
 columns as the "conflict target" in the ``ON CONFLICT`` clause. This usage
 requires that the targeted table have at least one column participating
-in a `PrimaryKeyConstraint`.
+in a :class:`.PrimaryKeyConstraint`.
 
 `ON CONFLICT` is also commonly used to skip inserting a row entirely
-if any conflict occurs. To do this, use the value 'nothing' for the keyword argument:
+if any conflict occurs. To do this, use the value 'nothing' for the keyword argument::
 
     table.insert(postgresql_on_conflict='nothing').\\
         values(key_column='existing_value', other_column='foo')
 
 Less commonly, you may need to specify which of several unique constraints on a table
 should be used to determine if an insert conflict exists. In these cases, use
-the :class:`.DoNothing` or :class:`.DoUpdate` object, and pass one of the following
+the :class:`.postgresql.DoNothing` or :class:`.postgresql.DoUpdate` object, and pass one of the following
 to indicate the "conflict target" constraint:
 
 * a single Column object or string with the column's name
@@ -296,11 +296,11 @@ to indicate the "conflict target" constraint:
   or :class:`.postgresql.ExcludeConstraint` object representing
   the unique constraint to target.
 
-If you use :class:`.DoUpdate`, you need to specify which columns on the existing row
+If you use :class:`.postgresql.DoUpdate`, you need to specify which columns on the existing row
 to set with values from the row proposed for insert. Use the
-:meth:`.DoUpdate.set_with_excluded` chaining method to do so, passing a variable
+:meth:`.postgresql.DoUpdate.set_with_excluded` chaining method to do so, passing a variable
 set of Column or Column name string arguments for the columns to set using
-the special `excluded` alias representing the row proposed for insertion:
+PostgreSQL's special `excluded` alias representing the row proposed for insertion::
 
     from sqlalchemy.dialects.postgresql import DoUpdate, DoNothing
     from sqlalchemy.schema import UniqueConstraint
@@ -317,7 +317,7 @@ not yet supported or documented by the dialect. Use text-based statements
 for more advanced ``ON CONFLICT`` clauses. 
 
 For more information on the PostgreSQL feature, see the
-``ON CONFLICT` section of the `INSERT` statement in the PostgreSQL docs 
+`ON CONFLICT section of the INSERT statement in the PostgreSQL docs 
 <http://www.postgresql.org/docs/current/static/sql-insert.html#SQL-ON-CONFLICT>`_.
 
 .. _postgresql_match:

--- a/lib/sqlalchemy/dialects/postgresql/on_conflict.py
+++ b/lib/sqlalchemy/dialects/postgresql/on_conflict.py
@@ -14,7 +14,7 @@ class _EXCLUDED:
 def resolve_on_conflict_option(option_value, crud_columns):
     if option_value is None:
         return None
-    if isinstance(option_value, OnConflictAction):
+    if isinstance(option_value, OnConflictClause):
         return option_value
     if str(option_value) == 'update':
         if not crud_columns:
@@ -31,12 +31,12 @@ def resolve_on_conflict_option(option_value, crud_columns):
     if str(option_value) == 'nothing':
         return DoNothing()
 
-class OnConflictAction(ClauseElement):
+class OnConflictClause(ClauseElement):
     def __init__(self, conflict_target):
-        super(OnConflictAction, self).__init__()
+        super(OnConflictClause, self).__init__()
         self.conflict_target = conflict_target
 
-class DoUpdate(OnConflictAction):
+class DoUpdate(OnConflictClause):
     """
     Represents an ``ON CONFLICT`` clause with a  ``DO UPDATE SET ...`` action.
     """
@@ -45,9 +45,10 @@ class DoUpdate(OnConflictAction):
         :param conflict_target:
           One of the following: A single :class:`.Column` object to string with column name;
           a list or tuple of :class:`.Column` or column name strings;
-          or a single :class:`.PrimaryKeyConstraint`, :class:`.UniqueConstraint`, 
-          or :class:`.postgresql.ExcludeConstraint`.  This value represents the 
-          unique constraint to target for conflict detection.
+          a single :class:`.PrimaryKeyConstraint`, :class:`.UniqueConstraint`, 
+          or :class:`.postgresql.ExcludeConstraint`;
+          or an :class:`.Index` object representing the constraint.  
+          This value represents the unique constraint to target for conflict detection.
         """
         super(DoUpdate, self).__init__(ConflictTarget(conflict_target))
         if not self.conflict_target.contents:
@@ -71,7 +72,7 @@ class DoUpdate(OnConflictAction):
             self.values_to_set[col] = _EXCLUDED
         return self
 
-class DoNothing(OnConflictAction):
+class DoNothing(OnConflictClause):
     """
     Represents an ``ON CONFLICT` clause with a ``DO NOTHING`` action.
     """
@@ -81,8 +82,10 @@ class DoNothing(OnConflictAction):
           Optional argument. If specified, one of the following:
           a single :class:`.Column` object to string with column name;
           a list or tuple of :class:`.Column` or column name strings;
-          or a single :class:`.PrimaryKeyConstraint`, :class:`.UniqueConstraint`, 
-          or :class:`.postgresql.ExcludeConstraint`. This value represents 
+          a single :class:`.PrimaryKeyConstraint`, :class:`.UniqueConstraint`, 
+          or :class:`.postgresql.ExcludeConstraint`; 
+          or an :class:`.Index` object representing a constraint. 
+          This value represents 
           the unique constraint to target for conflict detection.
           If omitted, allows any unique constraint violation to cause
           the row insertion to be skipped.
@@ -94,7 +97,7 @@ class ConflictTarget(ClauseElement):
     """
     A ConflictTarget represents the targeted constraint that will be used to determine
     when a row proposed for insertion is in conflict and should be handled as specified
-    in the OnConflictAction.
+    in the OnConflictClause.
 
     A target can be one of the following:
 

--- a/lib/sqlalchemy/dialects/postgresql/on_conflict.py
+++ b/lib/sqlalchemy/dialects/postgresql/on_conflict.py
@@ -62,7 +62,6 @@ class DoUpdate(OnConflictClause):
           These columns will be added to the ``SET`` clause using the `excluded` row's
           values from the same columns. e.g. ``SET colname = excluded.colname``.
         """
-        super(DoUpdate, self).__init__(ConflictTarget(conflict_target))
         for col in columns:
             if not isinstance(col, (ColumnClause, str)):
                 raise ValueError(
@@ -90,7 +89,6 @@ class DoNothing(OnConflictClause):
           If omitted, allows any unique constraint violation to cause
           the row insertion to be skipped.
         """
-        super(DoUpdate, self).__init__(ConflictTarget(conflict_target))
         super(DoNothing, self).__init__(ConflictTarget(conflict_target) if conflict_target else None)
 
 class ConflictTarget(ClauseElement):

--- a/lib/sqlalchemy/dialects/postgresql/on_conflict.py
+++ b/lib/sqlalchemy/dialects/postgresql/on_conflict.py
@@ -1,0 +1,81 @@
+from sqlalchemy.sql.expression import ClauseElement, ColumnClause, ColumnElement
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.exc import CompileError
+
+__all__ = ('DoUpdate', 'DoNothing')
+
+def resolve_on_conflict_option(option_value, crud_columns):
+    if option_value is None:
+        return None
+    if isinstance(option_value, OnConflictBase):
+        return option_value
+    if str(option_value).lower() in ('update', 'do update'):
+        if not crud_columns:
+            raise CompileError("Cannot perform postgresql_on_conflict='update' when no insert columns are available")
+        return DoUpdate([c[0] for c in crud_columns if c[0].primary_key]).with_excluded([c[0] for c in crud_columns if not c[0].primary_key])
+    if str(option_value).lower() in ('nothing', 'do nothing'):
+        return DoNothing()
+
+def resolve_columnish_arg(arg):
+    for col in (arg if isinstance(arg, (list, tuple)) else (arg,)):
+        if not isinstance(col, (ColumnClause, str)):
+            raise ValueError("column arguments must be ColumnClause objects or str object with column name: %r" % col)
+    return tuple(arg) if isinstance(arg, (list, tuple)) else (arg,)
+
+class OnConflictBase(ClauseElement):
+    def __init__(self, conflict_target):
+        super(OnConflictBase, self).__init__()
+        if not isinstance(conflict_target, ConflictTarget):
+            conflict_target = ConflictTarget(conflict_target)
+        self.conflict_target = conflict_target
+
+class DoUpdate(OnConflictBase):
+    def __init__(self, conflict_target):
+        super(DoUpdate, self).__init__(conflict_target)
+        if not self.conflict_target.content:
+            raise ValueError("conflict_target may not be None or empty for DoUpdate")
+        self.excluded_columns = None
+
+    def with_excluded(self, columns):
+        self.excluded_columns = resolve_columnish_arg(columns)
+        return self
+
+class DoNothing(OnConflictBase):
+    def __init__(self, conflict_target=[]):
+        super(DoNothing, self).__init__(conflict_target)
+
+class ConflictTarget(ClauseElement):
+    def __init__(self, content):
+        self.content = resolve_columnish_arg(content)
+
+@compiles(ConflictTarget)
+def compile_conflict_target(conflict_target, compiler, **kw):
+    if not conflict_target.content:
+        return ''
+    return "(" + (", ".join(compiler.preparer.format_column(i) for i in conflict_target.content)) + ")"
+
+@compiles(DoUpdate)
+def compile_do_update(do_update, compiler, **kw):
+    compiled_cf = compiler.process(do_update.conflict_target)
+    if not compiled_cf:
+        raise Exception("Can't have empty conflict_target")
+    text = "ON CONFLICT %s DO UPDATE" % compiled_cf
+    if do_update.excluded_columns:
+        names = []
+        for col in do_update.excluded_columns:
+            fmt_name = compiler.preparer.format_column(col) if isinstance(col, ColumnClause) else col
+            names.append("%s = excluded.%s" % (fmt_name, fmt_name))
+        text += (
+            " SET " + 
+            ", ".join(names)
+            )
+    return text
+
+@compiles(DoNothing)
+def compile_do_nothing(do_nothing, compiler, **kw):
+    compiled_cf = compiler.process(do_nothing.conflict_target)
+    if compiled_cf:
+        return "ON CONFLICT %s DO NOTHING" % compiled_cf
+    else:
+        return "ON CONFLICT DO NOTHING"
+

--- a/lib/sqlalchemy/dialects/postgresql/on_conflict.py
+++ b/lib/sqlalchemy/dialects/postgresql/on_conflict.py
@@ -1,19 +1,27 @@
-from sqlalchemy.sql.expression import ClauseElement, ColumnClause, ColumnElement
-from sqlalchemy.ext.compiler import compiles
-from sqlalchemy.exc import CompileError
+from ...sql.expression import ClauseElement, ColumnClause, ColumnElement
+from ...ext.compiler import compiles
+from ...exc import CompileError
 
 __all__ = ('DoUpdate', 'DoNothing')
+
+class _EXCLUDED:
+    pass
 
 def resolve_on_conflict_option(option_value, crud_columns):
     if option_value is None:
         return None
-    if isinstance(option_value, OnConflictBase):
+    if isinstance(option_value, OnConflictAction):
         return option_value
-    if str(option_value).lower() in ('update', 'do update'):
+    if str(option_value) == 'update':
         if not crud_columns:
-            raise CompileError("Cannot perform postgresql_on_conflict='update' when no insert columns are available")
-        return DoUpdate([c[0] for c in crud_columns if c[0].primary_key]).with_excluded([c[0] for c in crud_columns if not c[0].primary_key])
-    if str(option_value).lower() in ('nothing', 'do nothing'):
+            raise CompileError("Cannot compile postgresql_on_conflict='update' option when no insert columns are available")
+        crud_table_pk = crud_columns[0][0].table.primary_key
+        if not crud_table_pk.columns:
+            raise CompileError("Cannot compile postgresql_on_conflict='update' option when no target table has no primary key column(s)")
+        return DoUpdate(crud_table_pk.columns.values()).set_with_excluded(
+            *[c[0] for c in crud_columns if not crud_table_pk.contains_column(c[0])]
+            )
+    if str(option_value) == 'nothing':
         return DoNothing()
 
 def resolve_columnish_arg(arg):
@@ -22,53 +30,60 @@ def resolve_columnish_arg(arg):
             raise ValueError("column arguments must be ColumnClause objects or str object with column name: %r" % col)
     return tuple(arg) if isinstance(arg, (list, tuple)) else (arg,)
 
-class OnConflictBase(ClauseElement):
+class OnConflictAction(ClauseElement):
     def __init__(self, conflict_target):
-        super(OnConflictBase, self).__init__()
+        super(OnConflictAction, self).__init__()
         if not isinstance(conflict_target, ConflictTarget):
             conflict_target = ConflictTarget(conflict_target)
         self.conflict_target = conflict_target
 
-class DoUpdate(OnConflictBase):
+class DoUpdate(OnConflictAction):
     def __init__(self, conflict_target):
         super(DoUpdate, self).__init__(conflict_target)
-        if not self.conflict_target.content:
+        if not self.conflict_target.contents:
             raise ValueError("conflict_target may not be None or empty for DoUpdate")
-        self.excluded_columns = None
+        self.values_to_set = {}
 
-    def with_excluded(self, columns):
-        self.excluded_columns = resolve_columnish_arg(columns)
+    def set_with_excluded(self, *columns):
+        for col in resolve_columnish_arg(columns):
+           self.values_to_set[col] = _EXCLUDED
         return self
 
-class DoNothing(OnConflictBase):
+class DoNothing(OnConflictAction):
     def __init__(self, conflict_target=[]):
         super(DoNothing, self).__init__(conflict_target)
 
 class ConflictTarget(ClauseElement):
-    def __init__(self, content):
-        self.content = resolve_columnish_arg(content)
+    def __init__(self, contents):
+        self.contents = resolve_columnish_arg(contents)
 
 @compiles(ConflictTarget)
 def compile_conflict_target(conflict_target, compiler, **kw):
-    if not conflict_target.content:
+    if not conflict_target.contents:
         return ''
-    return "(" + (", ".join(compiler.preparer.format_column(i) for i in conflict_target.content)) + ")"
+    return "(" + (", ".join(compiler.preparer.format_column(i) for i in conflict_target.contents)) + ")"
 
 @compiles(DoUpdate)
 def compile_do_update(do_update, compiler, **kw):
     compiled_cf = compiler.process(do_update.conflict_target)
     if not compiled_cf:
-        raise Exception("Can't have empty conflict_target")
+        raise CompileError("Cannot have empty conflict_target")
     text = "ON CONFLICT %s DO UPDATE" % compiled_cf
-    if do_update.excluded_columns:
-        names = []
-        for col in do_update.excluded_columns:
-            fmt_name = compiler.preparer.format_column(col) if isinstance(col, ColumnClause) else col
-            names.append("%s = excluded.%s" % (fmt_name, fmt_name))
-        text += (
-            " SET " + 
-            ", ".join(names)
-            )
+    if not do_update.values_to_set:
+        raise CompileEror("Cannot have empty set of values to SET in DO UPDATE") 
+    names = []
+    for col, value in do_update.values_to_set.items():
+        fmt_name = compiler.preparer.format_column(col) if isinstance(col, ColumnClause) else col
+        if value is _EXCLUDED:
+            fmt_value = "excluded.%s" % fmt_name
+        else:
+            # TODO support expressions/literals, other than excluded
+            raise CompileError("Value to SET in DO UPDATE of unsupported type: %r" % value)
+        names.append("%s = %s" % (fmt_name, fmt_value))
+    text += (
+        " SET " + 
+        ", ".join(names)
+        )
     return text
 
 @compiles(DoNothing)

--- a/lib/sqlalchemy/dialects/postgresql/on_conflict.py
+++ b/lib/sqlalchemy/dialects/postgresql/on_conflict.py
@@ -2,6 +2,7 @@ from ...sql.expression import ClauseElement, ColumnClause, ColumnElement
 from ...ext.compiler import compiles
 from ...exc import CompileError
 from ...schema import UniqueConstraint, PrimaryKeyConstraint, Index
+from .ext import ExcludeConstraint
 
 from collections import Iterable
 
@@ -9,8 +10,6 @@ __all__ = ('DoUpdate', 'DoNothing')
 
 class _EXCLUDED:
     pass
-
-ExcludeConstraint = None
 
 def resolve_on_conflict_option(option_value, crud_columns):
     if option_value is None:
@@ -76,9 +75,6 @@ class ConflictTarget(ClauseElement):
       opclass used to detect conflict, and WHERE clauses for partial indexes.
     """
     def __init__(self, contents):
-        global ExcludeConstraint
-        if ExcludeConstraint is None:
-            from .ext import ExcludeConstraint
         if isinstance(contents, (str, ColumnClause)):
             self.contents = (contents,)
         elif isinstance(contents, (list, tuple)):
@@ -97,9 +93,6 @@ class ConflictTarget(ClauseElement):
 
 @compiles(ConflictTarget)
 def compile_conflict_target(conflict_target, compiler, **kw):
-    global ExcludeConstraint
-    if ExcludeConstraint is None:
-        from .ext import ExcludeConstraint
     target = conflict_target.contents
     if isinstance(target, (PrimaryKeyConstraint, UniqueConstraint, ExcludeConstraint)):
         fmt_cnst = None

--- a/lib/sqlalchemy/dialects/postgresql/on_conflict.py~
+++ b/lib/sqlalchemy/dialects/postgresql/on_conflict.py~
@@ -38,16 +38,17 @@ class OnConflictAction(ClauseElement):
 
 class DoUpdate(OnConflictAction):
     """
-    Represents an ``ON CONFLICT`` clause with a  ``DO UPDATE SET ...`` action.
+    Represents an `ON CONFLICT` clause with a  `DO UPDATE SET ...` action.
     """
     def __init__(self, conflict_target):
         """
         :param conflict_target:
-          One of the following: A single :class:`.Column` object to string with column name;
-          a list or tuple of :class:`.Column` or column name strings;
-          or a single :class:`.PrimaryKeyConstraint`, :class:`.UniqueConstraint`, 
-          or :class:`.postgresql.ExcludeConstraint`.  This value represents the 
-          unique constraint to target for conflict detection.
+          One of the following:
+          * A single :class:`.Column` object to string with column name
+          * A list or tuple of :class:`.Column` or column name strings
+          * A single :class:`.PrimaryKeyConstraint`, :class:`.UniqueConstraint`, 
+            or :class:`.postgresql.ExcludeConstraint` 
+          This value represents the unique constraint to target for conflict detection.
         """
         super(DoUpdate, self).__init__(ConflictTarget(conflict_target))
         if not self.conflict_target.contents:
@@ -57,9 +58,7 @@ class DoUpdate(OnConflictAction):
     def set_with_excluded(self, *columns):
         """
         :param \*columns:
-          One or more :class:`.Column` objects or strings representing column names.
-          These columns will be added to the ``SET`` clause using the `excluded` row's
-          values from the same columns. e.g. ``SET colname = excluded.colname``.
+          One or more :class:`.Column` objects or strings representing column names
         """
         super(DoUpdate, self).__init__(ConflictTarget(conflict_target))
         for col in columns:
@@ -73,19 +72,17 @@ class DoUpdate(OnConflictAction):
 
 class DoNothing(OnConflictAction):
     """
-    Represents an ``ON CONFLICT` clause with a ``DO NOTHING`` action.
+    Represents an `ON CONFLICT` clause with a `DO NOTHING` action.
     """
     def __init__(self, conflict_target=None):
         """
         :param conflict_target:
-          Optional argument. If specified, one of the following:
-          a single :class:`.Column` object to string with column name;
-          a list or tuple of :class:`.Column` or column name strings;
-          or a single :class:`.PrimaryKeyConstraint`, :class:`.UniqueConstraint`, 
-          or :class:`.postgresql.ExcludeConstraint`. This value represents 
-          the unique constraint to target for conflict detection.
-          If omitted, allows any unique constraint violation to cause
-          the row insertion to be skipped.
+          One of the following:
+          * A single :class:`.Column` object to string with column name
+          * A list or tuple of :class:`.Column` or column name strings
+          * A single :class:`.PrimaryKeyConstraint`, :class:`.UniqueConstraint`, 
+            or :class:`.postgresql.ExcludeConstraint` 
+          This value represents the unique constraint to target for conflict detection.
         """
         super(DoUpdate, self).__init__(ConflictTarget(conflict_target))
         super(DoNothing, self).__init__(ConflictTarget(conflict_target) if conflict_target else None)

--- a/test/dialect/postgresql/test_on_conflict.py
+++ b/test/dialect/postgresql/test_on_conflict.py
@@ -56,7 +56,7 @@ class OnConflictTest(fixtures.TestBase, AssertsExecutionResults, AssertsCompiled
             users.insert(postgresql_on_conflict=DoUpdate(users.c.id).set_with_excluded(users.c.name)).execute(id=1, name='name1')
             eq_(users.select().where(users.c.id == 1)
                 .execute().fetchall(), [(1, 'name1')])
-            users.insert(postgresql_on_conflict=DoUpdate(users.c.id).with_excluded([users.c.id, users.c.name])).execute(id=1, name='name2')
+            users.insert(postgresql_on_conflict=DoUpdate(users.c.id).set_with_excluded(users.c.id, users.c.name)).execute(id=1, name='name2')
             eq_(users.select().where(users.c.id == 1)
                 .execute().fetchall(), [(1, 'name2')])
             users.insert(postgresql_on_conflict='update').execute(id=1, name='name3')

--- a/test/dialect/postgresql/test_on_conflict.py
+++ b/test/dialect/postgresql/test_on_conflict.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+
+from sqlalchemy.testing.assertions import (
+    eq_, assert_raises, assert_raises_message, AssertsExecutionResults,
+    AssertsCompiledSQL)
+from sqlalchemy.testing import engines, fixtures
+from sqlalchemy import testing
+import datetime
+from sqlalchemy import (
+    Table, Column, select, MetaData, text, Integer, String, Sequence, Numeric,
+    DateTime, BigInteger, func, extract, SmallInteger)
+from sqlalchemy import exc, schema
+from sqlalchemy.dialects.postgresql import base as postgresql
+from sqlalchemy.dialects.postgresql.on_conflict import DoUpdate, DoNothing
+import logging
+import logging.handlers
+from sqlalchemy.testing.mock import Mock
+from sqlalchemy.engine import engine_from_config
+from sqlalchemy.engine import url
+from sqlalchemy.testing import is_
+from sqlalchemy.testing import expect_deprecated
+
+
+class OnConflictTest(fixtures.TestBase, AssertsExecutionResults, AssertsCompiledSQL):
+
+    __only_on__ = 'postgresql'
+    __backend__ = True
+
+    @testing.only_if(
+        "postgresql >= 9.5", "requires ON CONFLICT clause support")
+    def test_on_conflict_do_nothing(self):
+        meta = MetaData(testing.db)
+        users = Table(
+            'users', meta, Column(
+                'id', Integer, primary_key=True), Column(
+                'name', String(50)), schema='test_schema')
+        users.create()
+        try:
+            users.insert(postgresql_on_conflict='nothing').execute(id=1, name='name1')
+            users.insert(postgresql_on_conflict=DoNothing()).execute(id=1, name='name2')
+            eq_(users.select().where(users.c.id == 1)
+                .execute().fetchall(), [(1, 'name1')])
+        finally:
+            users.drop()
+
+    @testing.only_if(
+        "postgresql >= 9.5", "requires ON CONFLICT clause support")
+    def test_on_conflict_do_update(self):
+        meta = MetaData(testing.db)
+        users = Table(
+            'users', meta, Column(
+                'id', Integer, primary_key=True), Column(
+                'name', String(50)), schema='test_schema')
+        users.create()
+        try:
+            users.insert(postgresql_on_conflict=DoUpdate(users.c.id).with_excluded(users.c.name)).execute(id=1, name='name1')
+            eq_(users.select().where(users.c.id == 1)
+                .execute().fetchall(), [(1, 'name1')])
+            users.insert(postgresql_on_conflict=DoUpdate(users.c.id).with_excluded([users.c.id, users.c.name])).execute(id=1, name='name2')
+            eq_(users.select().where(users.c.id == 1)
+                .execute().fetchall(), [(1, 'name2')])
+            users.insert(postgresql_on_conflict='update').execute(id=1, name='name3')
+            eq_(users.select().where(users.c.id == 1)
+                .execute().fetchall(), [(1, 'name3')])
+            users.insert(postgresql_on_conflict='update', values=dict(id=1, name='name4')).execute()
+            eq_(users.select().where(users.c.id == 1)
+                .execute().fetchall(), [(1, 'name4')])
+        finally:
+            users.drop()

--- a/test/dialect/postgresql/test_on_conflict.py
+++ b/test/dialect/postgresql/test_on_conflict.py
@@ -53,7 +53,7 @@ class OnConflictTest(fixtures.TestBase, AssertsExecutionResults, AssertsCompiled
                 'name', String(50)), schema='test_schema')
         users.create()
         try:
-            users.insert(postgresql_on_conflict=DoUpdate(users.c.id).with_excluded(users.c.name)).execute(id=1, name='name1')
+            users.insert(postgresql_on_conflict=DoUpdate(users.c.id).set_with_excluded(users.c.name)).execute(id=1, name='name1')
             eq_(users.select().where(users.c.id == 1)
                 .execute().fetchall(), [(1, 'name1')])
             users.insert(postgresql_on_conflict=DoUpdate(users.c.id).with_excluded([users.c.id, users.c.name])).execute(id=1, name='name2')


### PR DESCRIPTION
Implementation, tests, and complete documentation for new support of INSERT ... ON CONFLICT in PostgreSQL 9.5 and later.

Tests pass for all three configured PG drivers: pg8000, psycopg2, and psycopg2cffi. In both Python 2.7 and Python 3.4.

Ticket #3529 is currently marked a "duplicate" of #960 (https://bitbucket.org/zzzeek/sqlalchemy/issues/960), but I would say that #3529 represents the dialect-specific support for postgresql ON CONFLICT. #960 represents a proposal to attempt a dialect-agnostic support for MERGE/upsert/etc.

Let me know if there's anything else I need to do for this PR: code formatting, code style, API usage, etc.

Thanks for maintaining SQLAlchemy; it's a fantastic piece of software to use!
