### PR TITLE
make check for None more specific

### DIFF
--- a/lib/sqlalchemy/orm/mapper.py
+++ b/lib/sqlalchemy/orm/mapper.py
@@ -1990,7 +1990,7 @@ class Mapper(InspectionAttr):
                 frozenset(
                     col.key for col in columns
                     if not col.primary_key and
-                    not col.server_default and not col.default
+                    col.server_default is None and col.default is None
                     and not col.type.should_evaluate_none)
             )
             for table, columns in self._cols_by_table.items()


### PR DESCRIPTION
Exception on session.commit() from `ClauseElement.__bool__` when adding an object with field where `server_default` is set to `text('some sql code')`