### PR TITLE
Create Table DDL options

### DIFF
--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -2216,7 +2216,7 @@ class DDLCompiler(Compiled):
         text = "\nCREATE "
         if table._prefixes:
             text += " ".join(table._prefixes) + " "
-        text += "TABLE " + preparer.format_table(table) + " ("
+        text += "TABLE " + preparer.format_table(table) + " " + self.table_options(table) + " ("
 
         separator = "\n"
 
@@ -2421,6 +2421,9 @@ class DDLCompiler(Compiled):
             colspec += " NOT NULL"
         return colspec
 
+    def table_options(self, table):
+        return ''
+        
     def post_create_table(self, table):
         return ''
 

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -2216,7 +2216,7 @@ class DDLCompiler(Compiled):
         text = "\nCREATE "
         if table._prefixes:
             text += " ".join(table._prefixes) + " "
-        text += "TABLE " + preparer.format_table(table) + " " + self.table_options(table) + " ("
+        text += "TABLE " + preparer.format_table(table) + " " + self.table_options(table) + "("
 
         separator = "\n"
 


### PR DESCRIPTION
Hi, I'm implementing a dialect for sqlalchemy and would like to add options to my CREATE TABLE DDL before the '(' but after the table name in visit_create_table. I know I can just subclass visit_create_table in my ddl compiler but it seems kind of silly since I'd be making a small change and reusing much of the same code. table_options is overridden by dialect ddl compilers to process dialect specific keywords to append to the create table statement.