### PR TITLE
Commiting a NestedTransaction Only Issues A RELEASE SAVEPOINT Statement

### DIFF
--- a/lib/sqlalchemy/engine/base.py
+++ b/lib/sqlalchemy/engine/base.py
@@ -1673,6 +1673,7 @@ class NestedTransaction(Transaction):
         if self.is_active:
             self.connection._release_savepoint_impl(
                 self._savepoint, self._parent)
+            self.connection._commit_impl()
 
 
 class TwoPhaseTransaction(Transaction):


### PR DESCRIPTION
Currently in our code we have to do the following in order to persist db changes:
```python
try:
    sp = session.begin_nested()
    obj = Obj()
    session.add(obj)
    session.flush()
except IntegrityError:
    sp.rollback()

# Only issues a RELEASE SAVEPOINT statement
session.commit()
# Actually calls COMMIT
session.commit()
```

Shouldn't SQLAlchemy call COMMIT on the first `commit()` instead of requiring two consecutive `commit()`s?
