### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/doc/build/changelog/changelog_08.rst
+++ b/doc/build/changelog/changelog_08.rst
@@ -2440,7 +2440,7 @@
         :tickets: 2589
 
       The Beaker caching example has been converted
-      to use `dogpile.cache <http://dogpilecache.readthedocs.org/>`_.
+      to use `dogpile.cache <https://dogpilecache.readthedocs.io/>`_.
       This is a new caching library written by the same
       creator of Beaker's caching internals, and represents a
       vastly improved, simplified, and modernized system of caching.

--- a/doc/build/changelog/migration_08.rst
+++ b/doc/build/changelog/migration_08.rst
@@ -578,7 +578,7 @@ that were not flushed in the current transaction.
 Caching Example now uses dogpile.cache
 ---------------------------------------
 
-The caching example now uses `dogpile.cache <http://dogpilecache.readthedocs.org/>`_.
+The caching example now uses `dogpile.cache <https://dogpilecache.readthedocs.io/>`_.
 Dogpile.cache is a rewrite of the caching portion
 of Beaker, featuring vastly simpler and faster operation,
 as well as support for distributed locking.

--- a/doc/build/changelog/migration_09.rst
+++ b/doc/build/changelog/migration_09.rst
@@ -1095,7 +1095,7 @@ can be dropped in using callable functions.
 
 It is hoped that the :class:`.AutomapBase` system provides a quick
 and modernized solution to the problem that the very famous
-`SQLSoup <https://sqlsoup.readthedocs.org/en/latest/>`_
+`SQLSoup <https://sqlsoup.readthedocs.io/en/latest/>`_
 also tries to solve, that of generating a quick and rudimentary object
 model from an existing database on the fly.  By addressing the issue strictly
 at the mapper configuration level, and integrating fully with existing

--- a/doc/build/conf.py
+++ b/doc/build/conf.py
@@ -373,7 +373,7 @@ epub_copyright = u'2007-2015, SQLAlchemy authors'
 #epub_tocdup = True
 
 intersphinx_mapping = {
-    'alembic': ('http://alembic.readthedocs.org/en/latest/', None),
+    'alembic': ('https://alembic.readthedocs.io/en/latest/', None),
     'psycopg2': ('http://pythonhosted.org/psycopg2', None),
 }
 

--- a/doc/build/core/constraints.rst
+++ b/doc/build/core/constraints.rst
@@ -426,7 +426,7 @@ parameters which create :class:`.UniqueConstraint` and :class:`.Index` objects
 without an explicit name being specified.
 
 The use case of alteration of existing tables and constraints can be handled
-by schema migration tools such as `Alembic <http://http://alembic.readthedocs.org/>`_.
+by schema migration tools such as `Alembic <https://alembic.readthedocs.io/>`_.
 However, neither Alembic nor SQLAlchemy currently create names for constraint
 objects where the name is otherwise unspecified, leading to the case where
 being able to alter existing constraints means that one must reverse-engineer

--- a/doc/build/core/metadata.rst
+++ b/doc/build/core/metadata.rst
@@ -243,7 +243,7 @@ database schemas in relation to application code using schema migration tools.
 
 There are two major migration tools available for SQLAlchemy:
 
-* `Alembic <http://alembic.readthedocs.org>`_ - Written by the author of SQLAlchemy,
+* `Alembic <https://alembic.readthedocs.io>`_ - Written by the author of SQLAlchemy,
   Alembic features a highly customizable environment and a minimalistic usage pattern,
   supporting such features as transactional DDL, automatic generation of "candidate"
   migrations, an "offline" mode which generates SQL scripts, and support for branch

--- a/doc/build/orm/session_basics.rst
+++ b/doc/build/orm/session_basics.rst
@@ -410,7 +410,7 @@ by default. This also defeats the purpose of using the Session as a cache.
 The :class:`.Session` is not designed to be a
 global object from which everyone consults as a "registry" of objects.
 That's more the job of a **second level cache**.   SQLAlchemy provides
-a pattern for implementing second level caching using `dogpile.cache <http://dogpilecache.readthedocs.org/>`_,
+a pattern for implementing second level caching using `dogpile.cache <https://dogpilecache.readthedocs.io/>`_,
 via the :ref:`examples_caching` example.
 
 How can I get the :class:`~sqlalchemy.orm.session.Session` for a certain object?

--- a/examples/dogpile_caching/__init__.py
+++ b/examples/dogpile_caching/__init__.py
@@ -1,5 +1,5 @@
 """
-Illustrates how to embed `dogpile.cache <http://dogpilecache.readthedocs.org/>`_
+Illustrates how to embed `dogpile.cache <https://dogpilecache.readthedocs.io/>`_
 functionality within
 the :class:`.Query` object, allowing full cache control as well as the
 ability to pull "lazy loaded" attributes from long term cache

--- a/lib/sqlalchemy/ext/automap.py
+++ b/lib/sqlalchemy/ext/automap.py
@@ -13,7 +13,7 @@ schema, typically though not necessarily one which is reflected.
 
 It is hoped that the :class:`.AutomapBase` system provides a quick
 and modernized solution to the problem that the very famous
-`SQLSoup <https://sqlsoup.readthedocs.org/en/latest/>`_
+`SQLSoup <https://sqlsoup.readthedocs.io/en/latest/>`_
 also tries to solve, that of generating a quick and rudimentary object
 model from an existing database on the fly.  By addressing the issue strictly
 at the mapper configuration level, and integrating fully with existing


### PR DESCRIPTION
As per their email ‘Changes to project subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.