### PR TITLE
Add regexp operators for PostgreSQL string types.

### DIFF
--- a/doc/build/dialects/postgresql.rst
+++ b/doc/build/dialects/postgresql.rst
@@ -44,6 +44,8 @@ construction arguments, are as follows:
 .. autoclass:: BYTEA
     :members: __init__
 
+.. autoclass:: CHAR
+
 .. autoclass:: CIDR
 
 
@@ -85,11 +87,20 @@ construction arguments, are as follows:
 .. autoclass:: REAL
     :members: __init__
 
+.. autoclass:: TEXT
+
 .. autoclass:: TSVECTOR
     :members: __init__
 
 .. autoclass:: UUID
     :members: __init__
+
+.. autoclass:: VARCHAR
+
+The string types get additional functionality from the following mixin:
+
+.. autoclass:: sqlalchemy.dialects.postgresql.base._PGStringOps
+    :members: Comparator
 
 
 Range Types


### PR DESCRIPTION
Adapted from patch started in [#1390 (BitBucket)](https://bitbucket.org/zzzeek/sqlalchemy/issues/1390/postgresql-regular-expression-operators)

Maybe the documentation could be organised differently, I didn't put the string types and mixin class into their own subsection like range operators.

Maybe `_PGStringOps` should be named differently? E.g. the range types mixin is just called `RangeOperators`.

I used `default_comparator._boolean_compare` because I think that's what the patch was trying to do (which had `self.expr._boolean_compare`, which didn't work so I assume an old API).

The operations get grouped in the where clause `(t.x ~ %(x_1)s)`, maybe that's wrong (well harmless, but not necessary?)