### PR TITLE
Raise error on empty in_

### DIFF
--- a/lib/sqlalchemy/sql/default_comparator.py
+++ b/lib/sqlalchemy/sql/default_comparator.py
@@ -146,6 +146,7 @@ def _in_impl(expr, op, seq_or_selectable, negate_op, **kw):
         # build the contradiction as it handles NULL values
         # appropriately, i.e. "not (x IN ())" should not return NULL
         # values for x.
+        assert False, 'empty in'
 
         util.warn('The IN-predicate on "%s" was invoked with an '
                   'empty sequence. This results in a '


### PR DESCRIPTION

I think it would be good idea to add error on empy in_ usage in version 1.1.*
Because current implementation is not fully correct:
Firstly, it's not optimised, because of sequential scan
Secondly, in current implementation null in () will return null, when in sql it should return False, try this:
select null in (select 1 from some_table where false); -> false but not null

I understant that this can break some legacy code, but current implementation is obscure and quite expensive