### PR TITLE
Adding Snowflake SQLAlchemy dialect Github link to SQLAlchemy dialect index page

### DIFF
--- a/doc/build/dialects/index.rst
+++ b/doc/build/dialects/index.rst
@@ -54,7 +54,7 @@ Production Ready
 * `sqlalchemy-sqlany <https://github.com/sqlanywhere/sqlalchemy-sqlany>`_ - driver for SAP Sybase SQL
   Anywhere, developed by SAP.
 * `sqlalchemy-monetdb <https://github.com/gijzelaerr/sqlalchemy-monetdb>`_ - driver for MonetDB.
-* `snowflake-sqlalchemy <https://github.com/snowflakedb/snowflake-sqlalchemy>`_ - driver for `Snowflake <https://www.snowflake.net/`_.
+* `snowflake-sqlalchemy <https://github.com/snowflakedb/snowflake-sqlalchemy>`_ - driver for `Snowflake <https://www.snowflake.net/>`_.
 
 Experimental / Incomplete
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/build/dialects/index.rst
+++ b/doc/build/dialects/index.rst
@@ -54,6 +54,7 @@ Production Ready
 * `sqlalchemy-sqlany <https://github.com/sqlanywhere/sqlalchemy-sqlany>`_ - driver for SAP Sybase SQL
   Anywhere, developed by SAP.
 * `sqlalchemy-monetdb <https://github.com/gijzelaerr/sqlalchemy-monetdb>`_ - driver for MonetDB.
+* `snowflake-sqlalchemy <https://github.com/snowflakedb/snowflake-sqlalchemy>`_ - driver for `Snowflake <https://www.snowflake.net/`_.
 
 Experimental / Incomplete
 ^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Hi, I would like to add the link to Snowflake SQLAlchemy dialect Github page.
Thanks!