### PR TITLE
Add AppVeyor build with autoupload when commit is tagged with 'rel_*'

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,47 @@
+environment:
+  global:
+    PYPI_USERNAME:
+      secure: <insert secure variable here>
+    PYPI_PASSWORD:
+      secure: <insert secure variable here>
+
+  matrix:
+
+    # For Python versions available on Appveyor, see
+    # http://www.appveyor.com/docs/installed-software#python
+
+    - PYTHON: "C:\\Python26"
+    - PYTHON: "C:\\Python27"
+    - PYTHON: "C:\\Python33"
+    - PYTHON: "C:\\Python34"
+    - PYTHON: "C:\\Python35"
+    - PYTHON: "C:\\Python26-x64"
+    - PYTHON: "C:\\Python27-x64"
+    - PYTHON: "C:\\Python33-x64"
+      DISTUTILS_USE_SDK: "1"
+    - PYTHON: "C:\\Python34-x64"
+      DISTUTILS_USE_SDK: "1"
+    - PYTHON: "C:\\Python35-x64"
+
+version: "{build}"
+
+install:
+  # We need wheel installed to build wheels
+  - "%PYTHON%\\Scripts\\pip.exe install -U twine wheel"
+
+build_script:
+  # Put your build command here.
+  # If you don't need to build C extensions on 64-bit Python 3.3 or 3.4,
+  # you can remove "build.cmd" from the front of the command, as it's
+  # only needed to support those cases.
+  # Note that you must use the environment variable %PYTHON% to refer to
+  # the interpreter you're using - Appveyor does not do anything special
+  # to put the Python version you want to use on PATH.
+  - "appveyor\\build.cmd %PYTHON%\\python.exe setup.py bdist_wheel"
+
+after_build:
+  - "appveyor\\after_build.bat"
+
+artifacts:
+  # bdist_wheel puts your built wheel in the dist directory
+  - path: dist\*

--- a/appveyor/after_build.bat
+++ b/appveyor/after_build.bat
@@ -1,0 +1,6 @@
+appveyor\\build.cmd %PYTHON%\\python.exe setup.py bdist_wheel
+IF "%APPVEYOR_REPO_TAG%"=="true" (
+    IF "%APPVEYOR_REPO_TAG_NAME:~0,4%"=="rel_" (
+        %PYTHON%\\Scripts\\twine.exe upload -u %PYPI_USERNAME% -p %PYPI_PASSWORD% dist\*.whl
+    )
+)

--- a/appveyor/build.cmd
+++ b/appveyor/build.cmd
@@ -1,0 +1,21 @@
+@echo off
+:: To build extensions for 64 bit Python 3, we need to configure environment
+:: variables to use the MSVC 2010 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 4
+::
+:: More details at:
+:: https://github.com/cython/cython/wiki/64BitCythonExtensionsOnWindows
+
+IF "%DISTUTILS_USE_SDK%"=="1" (
+    ECHO Configuring environment to build with MSVC on a 64bit architecture
+    ECHO Using Windows SDK 7.1
+    "C:\Program Files\Microsoft SDKs\Windows\v7.1\Setup\WindowsSdkVer.exe" -q -version:v7.1
+    CALL "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64 /release
+    SET MSSdk=1
+    REM Need the following to allow tox to see the SDK compiler
+    SET TOX_TESTENV_PASSENV=DISTUTILS_USE_SDK MSSdk INCLUDE LIB
+) ELSE (
+    ECHO Using default MSVC build environment
+)
+
+CALL %*

--- a/appveyor/getwheels.py
+++ b/appveyor/getwheels.py
@@ -1,0 +1,78 @@
+# coding: utf-8
+from __future__ import absolute_import, division, print_function
+
+import os
+import sys
+from textwrap import dedent
+
+import requests
+
+URL = 'https://ci.appveyor.com/api'
+TOKEN = os.getenv('APPVEYOR_TOKEN')
+ACCOUNT = 'zzzeek'  # AppVeyor username, assuming zzzeek
+PROJECT = 'sqlalchemy'
+
+if len(sys.argv) != 2:
+    sys.exit('getwheels.py <branch>')
+
+if TOKEN is None:
+    sys.exit('APPVEYOR_TOKEN env var not set.')
+
+branch = sys.argv[1]
+
+session = requests.Session()
+session.headers.update({'Authorization': 'Bearer ' + TOKEN})
+
+BRANCH_BUILD_URL = '{}/projects/{}/{}/branch/{}'.format(
+    URL, ACCOUNT, PROJECT, branch)
+
+response = session.get(BRANCH_BUILD_URL)
+response.raise_for_status()
+
+build_data = response.json()['build']
+
+message = dedent('''
+    Downloading wheels for latest build on branch {bd[branch]!r}.
+
+    Branch:          {bd[branch]}
+    AppVeyor build:  {bd[buildNumber]}
+    Commit ID:       {bd[commitId]}
+    Commit message:  {bd[message]}
+
+    Build status:    {bd[status]}
+'''.format(bd=build_data))
+
+print(message)
+
+if build_data['status'] == 'failed':
+    sys.exit('Build failed, aborting download.')
+elif build_data['status'] == 'running':
+    sys.exit('Build still running, aborting download.')
+
+job_ids = [job['jobId'] for job in build_data['jobs']]
+
+
+def download_artifact(artifact):
+    FILE_URL = '{}/buildjobs/{}/artifacts'.format(
+        URL, job_id, artifact['fileName'])
+
+    print('Downloading', artifact['fileName'])
+
+    response = session.get(FILE_URL, stream=True)
+    response.raise_for_status()
+
+    with open(artifact['fileName'], 'wb') as fp:
+        for chunk in response.iter_content(chunk_size=100 * 1024):
+            fp.write(chunk)
+
+try:
+    os.mkdir('dist')
+except OSError:
+    pass
+
+for job_id in job_ids:
+    ARTIFACTS_URL = '{}/buildjobs/{}/artifacts'.format(URL, job_id)
+    response = session.get(ARTIFACTS_URL)
+    for artifact in response.json():
+        if artifact['fileName'].endswith('.whl'):
+            download_artifact(artifact)


### PR DESCRIPTION
As discussed in [#3747 (BitBucket)](https://bitbucket.org/zzzeek/sqlalchemy/issues/3747/windows-wheels)
1. Create an AppVeyor account and enable the SQLAlchemy repository (presumably the bitbucket one).
2. Encrypt PyPI credentials on AppVeyor by clicking your name at the top right and clicking "Encrypt data" under "Tools".

![image](https://cloud.githubusercontent.com/assets/1337586/16968279/256099ce-4e0e-11e6-9c7b-61124921974a.png)
3. Put those values in `appveyor.yml`.

I've included the `appveyor/getwheels.py` script, which may be useful if you want to download the latest wheels for a build. I can remove it if you don't want it in the repo.
