### PR TITLE
Oracle - optionally allow system tablespace in introspection

### DIFF
--- a/doc/build/dialects/oracle.rst
+++ b/doc/build/dialects/oracle.rst
@@ -53,6 +53,11 @@ construction arguments, are as follows:
   :members: __init__
 
 
+Note that table introspection on Oracle excludes tables in the
+SYSTEM or SYSAUX tablespaces by default. To change this behaviour,
+change the ``exclude_tablespaces`` parameter on the dialect.
+
+
 cx_Oracle
 ----------
 


### PR DESCRIPTION
Allow optionally overriding which Oracle tablespaces are excluded when introspecting table names.

By default (since at least 0.6) sqlalchemy has always excluded tables in the `SYSTEM` and `SYSAUX` tablespaces when introspecting table names.
However, in for example [Oracle XE 11g Express Edition](http://www.oracle.com/technetwork/database/database-technologies/express-edition/overview/index.html), the `SYSTEM` tablespace seems to be the default one used for newly created users (despite the documentation).
This means that sqlalchemy applications will fail to list tables created for these users unless the settings are changed (despite the tables being clearly present for the user's schema).
Also, column introspection fails as the table is not found in the list of table names.

Although it's obviously preferable to set up users with a different tablespace, there are situations where a developer may need to access these table names in spite of the unexpected table space.

In order to prevent adverse effects where the `SYSTEM` tablespace is not desired, this change simply introduces an `exclude_tablespaces` attribute on the dialect.
Overriding this will allow programs or libraries using sqlalchemy to adjust the list of tablespaces to be excluded.