### PR TITLE
Bulk Save Documentation

### DIFF
--- a/lib/sqlalchemy/orm/session.py
+++ b/lib/sqlalchemy/orm/session.py
@@ -2213,6 +2213,12 @@ class Session(_SessionClassMethods):
             **before using this method, and fully test and confirm the
             functionality of all code developed using these systems.**
 
+        .. warning::
+
+            Objects are processed in the order passed. Be sure to group objects
+            of the same type together (the list is sorted), else they will be
+            inserted in distinct batches.
+
         :param objects: a list of mapped object instances.  The mapped
          objects are persisted as is, and are **not** associated with the
          :class:`.Session` afterwards.


### PR DESCRIPTION
The session::bulk_save_objects method emphasizes performance, but
generates many insert statements when a variety of object types are
passed in an unordered list. This was a signification gotcha for me,
and seems contrary to the spirit of the method, so short of changing
the method to automatically sort the list, it should at least be
documented.