### PR TITLE
ORM: Allow suppress GROUP BY by passing None

### DIFF
--- a/lib/sqlalchemy/orm/query.py
+++ b/lib/sqlalchemy/orm/query.py
@@ -1551,6 +1551,11 @@ class Query(object):
         """apply one or more GROUP BY criterion to the query and return
         the newly resulting :class:`.Query`"""
 
+        if len(criterion) == 1:
+            if criterion[0] is None:
+                self._group_by = False
+                return
+
         criterion = list(chain(*[_orm_columns(c) for c in criterion]))
         criterion = self._adapt_col_list(criterion)
 

--- a/lib/sqlalchemy/orm/query.py
+++ b/lib/sqlalchemy/orm/query.py
@@ -1549,7 +1549,12 @@ class Query(object):
     @_generative(_no_statement_condition, _no_limit_offset)
     def group_by(self, *criterion):
         """apply one or more GROUP BY criterion to the query and return
-        the newly resulting :class:`.Query`"""
+        the newly resulting :class:`.Query`
+
+        All existing GROUP BY settings can be suppressed by passing
+        ``None``.
+
+        """
 
         if len(criterion) == 1:
             if criterion[0] is None:

--- a/test/orm/test_query.py
+++ b/test/orm/test_query.py
@@ -1574,6 +1574,17 @@ class ExpressionTest(QueryTest, AssertsCompiledSQL):
                     User(id=7, name='jack'),
                     Address(email_address='jack@bean.com', user_id=7, id=1))])
 
+    def test_group_by(self):
+        User = self.classes.User
+        s = create_session()
+
+        q1 = s.query(User.id, User.name).group_by(User.name)
+        self.assert_compile(
+            select([q1]),
+            "SELECT users_id, users_name FROM (SELECT users.id AS users_id, "
+            "users.name AS users_name FROM users GROUP BY users.name)"
+        )
+
 
 class ColumnPropertyTest(_fixtures.FixtureTest, AssertsCompiledSQL):
     __dialect__ = 'default'

--- a/test/orm/test_query.py
+++ b/test/orm/test_query.py
@@ -1592,6 +1592,20 @@ class ExpressionTest(QueryTest, AssertsCompiledSQL):
             "users.name AS users_name FROM users GROUP BY users.name, users.id)"
         )
 
+        # test cancellation by using None, replacement with something else
+        self.assert_compile(
+            select([q1.group_by(None).group_by(User.id)]),
+            "SELECT users_id, users_name FROM (SELECT users.id AS users_id, "
+            "users.name AS users_name FROM users GROUP BY users.id)"
+        )
+
+        # test cancellation by using None, replacement with nothing
+        self.assert_compile(
+            select([q1.group_by(None)]),
+            "SELECT users_id, users_name FROM (SELECT users.id AS users_id, "
+            "users.name AS users_name FROM users)"
+        )
+
 
 class ColumnPropertyTest(_fixtures.FixtureTest, AssertsCompiledSQL):
     __dialect__ = 'default'

--- a/test/orm/test_query.py
+++ b/test/orm/test_query.py
@@ -1585,6 +1585,13 @@ class ExpressionTest(QueryTest, AssertsCompiledSQL):
             "users.name AS users_name FROM users GROUP BY users.name)"
         )
 
+        # test append something to group_by
+        self.assert_compile(
+            select([q1.group_by(User.id)]),
+            "SELECT users_id, users_name FROM (SELECT users.id AS users_id, "
+            "users.name AS users_name FROM users GROUP BY users.name, users.id)"
+        )
+
 
 class ColumnPropertyTest(_fixtures.FixtureTest, AssertsCompiledSQL):
     __dialect__ = 'default'


### PR DESCRIPTION
The propose of this feature is to allow suppress any `GROUP BY` in ORM by passing `None` to `Query.group_by` like `Query.order_by` already does.

The SQLAlchemy Core already has this behavior, so it's interesting to have the same functionality in ORM.

Changes:

* ORM: Adding missing test for `group_by`
* ORM: Adding test for append something to `group_by`
* ORM: Adding tests for cancellation of `group_by` by passing `None`
* ORM: Allowing suppress `GROUP BY` by passing `None` on `Query.group_by`
* ORM: New docstring for `Query.group_by`