### PR TITLE
Clarify mappers.configure_mappers error messaage

### DIFF
--- a/lib/sqlalchemy/orm/mapper.py
+++ b/lib/sqlalchemy/orm/mapper.py
@@ -2826,10 +2826,10 @@ def configure_mappers():
             for mapper in list(_mapper_registry):
                 if getattr(mapper, '_configure_failed', False):
                     e = sa_exc.InvalidRequestError(
-                        "One or more mappers failed to initialize - "
+                        "One (%s) or more mappers failed to initialize - "
                         "can't proceed with initialization of other "
-                        "mappers.  Original exception was: %s"
-                        % mapper._configure_failed)
+                        "mappers. Original exception was: %s"
+                        % (mapper, mapper._configure_failed))
                     e._configure_failed = mapper._configure_failed
                     raise e
                 if not mapper.configured:

--- a/test/ext/declarative/test_basic.py
+++ b/test/ext/declarative/test_basic.py
@@ -772,9 +772,9 @@ class DeclarativeTest(DeclarativeTestBase):
         for i in range(3):
             assert_raises_message(
                 sa.exc.InvalidRequestError,
-                "^One or more mappers failed to initialize - "
-                "can't proceed with initialization of other "
-                "mappers.  Original exception was: When initializing.*",
+                "^One (Mapper|User|users) or more mappers failed to initialize"
+                " - can't proceed with initialization of other mappers. "
+                "Original exception was: When initializing.*",
                 configure_mappers)
 
     def test_custom_base(self):

--- a/test/orm/test_mapper.py
+++ b/test/orm/test_mapper.py
@@ -153,10 +153,10 @@ class MapperTest(_fixtures.FixtureTest, AssertsCompiledSQL):
 
         for i in range(3):
             assert_raises_message(sa.exc.InvalidRequestError,
-                                  "^One or more mappers failed to "
-                                  "initialize - can't proceed with "
-                                  "initialization of other mappers.  "
-                                  "Original exception was: Class "
+                                  "^One (Mapper|Address|addresses) or more "
+                                  "mappers failed to initialize - can't "
+                                  "proceed with initialization of other "
+                                  "mappers. Original exception was: Class "
                                   "'test.orm._fixtures.User' is not mapped$",
                                   configure_mappers)
 


### PR DESCRIPTION
Sometimes the message generated by configure_mappers lacks a reference
to the failing mapper, and only the mapper._configure_failed is shown. This
makes debugging problems extremely difficult. Example:

    sqlalchemy.exc.InvalidRequestError: One or more mappers failed to
    initialize - can't proceed with initialization of other mappers.  Original
    exception was: Class 'neutron.objects.router.Router' is not mapped

In the above failure, the actual object having a problem is FloatingIP, which
has a knock-on effect on the Router object when it fails to map. A more helpful
error message might look like this example:

    sqlalchemy.exc.InvalidRequestError: One (Mapper|FloatingIp|floatingip) or
    more mappers failed to initialize - can't proceed with initialization of
    other mappers.  Original exception was: Class
    'neutron.objects.router.Router' is not mapped

This patch adds the failing mapper name to the beginning of the message after
'One', as shown in the second example.

Change-Id: I9f23bfa90b26dde9229ab7ec812eec9ceae48153