### PR TITLE
Fix conn close behavior for thread local connections

### DIFF
--- a/lib/sqlalchemy/engine/threadlocal.py
+++ b/lib/sqlalchemy/engine/threadlocal.py
@@ -64,6 +64,8 @@ class TLEngine(base.Engine):
                     self.pool.connect, connection),
                 **kw)
             self._connections.conn = weakref.ref(connection)
+        else:
+            connection.should_close_with_result = kw.get('close_with_result', False)
 
         return connection._increment_connect()
 
@@ -81,11 +83,9 @@ class TLEngine(base.Engine):
             self.contextual_connect().begin_nested())
         return self
 
-    def begin(self):
-        if not hasattr(self._connections, 'trans'):
-            self._connections.trans = []
-        self._connections.trans.append(self.contextual_connect().begin())
-        return self
+    def begin(self, close_with_result=False):
+        conn = self.contextual_connect()
+        return base.Engine._trans_ctx(conn, conn.begin(), close_with_result)
 
     def __enter__(self):
         return self

--- a/test/engine/test_bind.py
+++ b/test/engine/test_bind.py
@@ -2,7 +2,7 @@
 including the deprecated versions of these arguments"""
 
 from sqlalchemy.testing import assert_raises, assert_raises_message
-from sqlalchemy import engine, exc
+from sqlalchemy import engine, exc, create_engine
 from sqlalchemy import MetaData, ThreadLocalMetaData
 from sqlalchemy import Integer, text
 from sqlalchemy.testing.schema import Table
@@ -21,6 +21,21 @@ class BindTest(fixtures.TestBase):
 
         with e.contextual_connect() as conn:
             assert not conn.closed
+        assert conn.closed
+
+    def test_tlbind_close_conn(self):
+        e = create_engine(testing.db.url, strategy='threadlocal')
+        conn = e.contextual_connect()
+        e.execute('select 1').fetchall()
+        conn.close()
+        assert conn.closed
+
+    def test_tlbind_close_trans_conn(self):
+        e = create_engine(testing.db.url, strategy='threadlocal')
+        conn = e.contextual_connect()
+        with e.begin():
+            pass
+        conn.close()
         assert conn.closed
 
     def test_bind_close_conn(self):


### PR DESCRIPTION
I know the thread local stuff isn't really prod worthy but I came across these two issues since we use strategy='threadlocal' when running tests.

The summary of both of these issues is that TLConnection.__opencount doesn't always get decremented properly in some scenarios so then calling conn.close() doesn't actually close the connection and a drop_db at test cleanup won't work because of active connections to the DB. I can workaround by using TLEngine.close() before .dispose() or TLConnection._force_close() but figured I'd attempt a fix in case it's useful.

1) engine.begin() doesn't explicitly call close() for transactions, so switch TLEngine.begin() to use the Engine._trans_ctx which does. I'm not sure if this behavior affects the other types of TLEngine transactions or not, I haven't tested those.
2) connectionless execution (engine.execute()) doesn't work properly if the TLConnection has already been checked out (with should_close_with_result=False) because TLEngine.contextual_connect() doesn't consume the close_with_result kwarg if the connection already exists. This is already a weird scenario of trying to have different values for that connection level attribute so this is not an all encompassing solution, but perhaps it's a step in the right direction.

Thanks!