### PR TITLE
Provide more informative error when joining with no entities

### DIFF
--- a/lib/sqlalchemy/orm/query.py
+++ b/lib/sqlalchemy/orm/query.py
@@ -2125,10 +2125,15 @@ class Query(object):
                 left = self._entities[0].entity_zero_or_selectable
 
         if left is None:
+            if self._entities:
+                problem = "Don't know how to join from %s" % self._entities[0]
+            else:
+                problem = "No entities to join from"
+
             raise sa_exc.InvalidRequestError(
-                "Don't know how to join from %s; please use "
+                "%s; please use "
                 "select_from() to establish the left "
-                "entity/selectable of this join" % self._entities[0])
+                "entity/selectable of this join" % problem)
 
         if left is right and \
                 not create_aliases:

--- a/test/orm/test_joins.py
+++ b/test/orm/test_joins.py
@@ -447,6 +447,19 @@ class JoinTest(QueryTest, AssertsCompiledSQL):
             sess.query(literal_column('x'), User).join, Address
         )
 
+    def test_left_is_none_and_query_has_no_entities(self):
+        User = self.classes.User
+        Address = self.classes.Address
+
+        sess = create_session()
+
+        assert_raises_message(
+            sa_exc.InvalidRequestError,
+            "No entities to join from; please use select_from\(\) to "
+            "establish the left entity/selectable of this join",
+            sess.query().join, Address
+        )
+
     def test_isouter_flag(self):
         User = self.classes.User
 


### PR DESCRIPTION
This prevents an `IndexError` when trying to join on a query that has entities, raising a more informative error instead.