### PR TITLE
orm.ext.declared_attr.cascading have incorrect example in docstring

### DIFF
--- a/doc/build/changelog/migration_10.rst
+++ b/doc/build/changelog/migration_10.rst
@@ -163,18 +163,17 @@ is affixed to the base class only, and just inherited from subclasses.
 With :attr:`.declared_attr.cascading`, individual behaviors can be
 applied::
 
-    class HasSomeAttribute(object):
+    class HasIdMixin(object):
         @declared_attr.cascading
-        def some_id(cls):
+        def id(cls):
             if has_inherited_table(cls):
-                return Column(ForeignKey('myclass.id'), primary_key=True)
+                return Column('id', Integer, primary_key=True)
             else:
-                return Column(Integer, primary_key=True)
+                return Column('id', Integer, ForeignKey('myclass.id'),
+                              primary_key=True)
 
-            return Column('id', Integer, primary_key=True)
-
-    class MyClass(HasSomeAttribute, Base):
-        ""
+    class MyClass(HasIdMixin, Base):
+        __tablename__ = 'myclass'
         # ...
 
     class MySubClass(MyClass):

--- a/doc/build/orm/extensions/declarative/mixins.rst
+++ b/doc/build/orm/extensions/declarative/mixins.rst
@@ -466,17 +466,17 @@ foreign key.  We can achieve this as a mixin by using the
 function should be invoked **for each class in the hierarchy**, just like
 it does for ``__tablename__``::
 
-    class HasId(object):
+    class HasIdMixin(object):
         @declared_attr.cascading
         def id(cls):
             if has_inherited_table(cls):
+                return Column('id', Integer, primary_key=True)
+            else:
                 return Column('id',
                               Integer,
                               ForeignKey('person.id'), primary_key=True)
-            else:
-                return Column('id', Integer, primary_key=True)
 
-    class Person(HasId, Base):
+    class Person(HasIdMixin, Base):
         __tablename__ = 'person'
         discriminator = Column('type', String(50))
         __mapper_args__ = {'polymorphic_on': discriminator}

--- a/lib/sqlalchemy/ext/declarative/api.py
+++ b/lib/sqlalchemy/ext/declarative/api.py
@@ -196,19 +196,17 @@ class declared_attr(interfaces._MappedAttribute, property):
         Below, both MyClass as well as MySubClass will have a distinct
         ``id`` Column object established::
 
-            class HasSomeAttribute(object):
+            class HasIdMixin(object):
                 @declared_attr.cascading
-                def some_id(cls):
+                def id(cls):
                     if has_inherited_table(cls):
-                        return Column(
-                            ForeignKey('myclass.id'), primary_key=True)
+                        return Column('id', Integer, primary_key=True)
                     else:
-                        return Column(Integer, primary_key=True)
+                        return Column('id', Integer, ForeignKey('myclass.id'),
+                                      primary_key=True)
 
-                    return Column('id', Integer, primary_key=True)
-
-            class MyClass(HasSomeAttribute, Base):
-                ""
+            class MyClass(HasIdMixin, Base):
+                __tablename__ = 'myclass'
                 # ...
 
             class MySubClass(MyClass):


### PR DESCRIPTION
There is an error in code example in docstring for
declared_attr.cascading.