### PR TITLE
fix scope_session.__call__

### DIFF
--- a/lib/sqlalchemy/orm/scoping.py
+++ b/lib/sqlalchemy/orm/scoping.py
@@ -62,18 +62,14 @@ class scoped_session(object):
 
         """
         if kw:
-            scope = kw.pop('scope', False)
-            if scope is not None:
-                if self.registry.has():
-                    raise sa_exc.InvalidRequestError(
-                        "Scoped session is already present; "
-                        "no new arguments may be specified.")
-                else:
-                    sess = self.session_factory(**kw)
-                    self.registry.set(sess)
-                    return sess
+            if self.registry.has():
+                raise sa_exc.InvalidRequestError(
+                    "Scoped session is already present; "
+                    "no new arguments may be specified.")
             else:
-                return self.session_factory(**kw)
+                sess = self.session_factory(**kw)
+                self.registry.set(sess)
+                return sess
         else:
             return self.registry()
 

--- a/test/orm/test_scoping.py
+++ b/test/orm/test_scoping.py
@@ -7,7 +7,7 @@ from sqlalchemy.testing.schema import Table, Column
 from sqlalchemy.orm import mapper, relationship, query
 from sqlalchemy.testing import eq_
 from sqlalchemy.testing import fixtures
-
+from sqlalchemy.testing.mock import Mock
 
 
 class _ScopedTest(fixtures.MappedTest):
@@ -90,5 +90,24 @@ class ScopedSessionTest(fixtures.MappedTest):
             Session.configure, bind=testing.db
         )
 
+    def test_call_with_kwargs(self):
+        mock_scope_func = Mock()
+        SessionMaker = sa.orm.sessionmaker()
+        Session = scoped_session(sa.orm.sessionmaker(), mock_scope_func)
 
+        s0 = SessionMaker()
+        assert s0.autocommit == False
 
+        mock_scope_func.return_value = 0
+        s1 = Session()
+        assert s1.autocommit == False
+
+        assert_raises_message(
+            sa.exc.InvalidRequestError,
+            "Scoped session is already present",
+            Session, autocommit=True
+        )
+
+        mock_scope_func.return_value = 1
+        s2 = Session(autocommit=True)
+        assert s2.autocommit == True


### PR DESCRIPTION
How the `scope` kw works? And why the default value is `False`? 
It is not mentioned in function doc. Can i believe it is redundant?
