### PR TITLE
exclude eq and ne from associative operators

### DIFF
--- a/lib/sqlalchemy/sql/operators.py
+++ b/lib/sqlalchemy/sql/operators.py
@@ -917,7 +917,7 @@ def mirror(op):
     return _mirror.get(op, op)
 
 
-_associative = _commutative.union([concat_op, and_, or_])
+_associative = _commutative.union([concat_op, and_, or_]).difference([eq, ne])
 
 _natural_self_precedent = _associative.union([
     getitem, json_getitem_op, json_path_getitem_op])

--- a/test/sql/test_operators.py
+++ b/test/sql/test_operators.py
@@ -1538,6 +1538,14 @@ class OperatorAssociativityTest(fixtures.TestBase, testing.AssertsCompiledSQL):
         f = column('f')
         self.assert_compile(f / (f / (f - f)), "f / (f / (f - f))")
 
+    def test_associativity_22(self):
+        f = column('f')
+        self.assert_compile((f==f) == f, '(f = f) = f')
+
+    def test_associativity_23(self):
+        f = column('f')
+        self.assert_compile((f!=f) != f, '(f != f) != f')
+
 
 class IsDistinctFromTest(fixtures.TestBase, testing.AssertsCompiledSQL):
     __dialect__ = 'default'


### PR DESCRIPTION
Recently, I discovered that my query for `(a.value != 0) != (b.value != 0)` compiled to `a.value != :value_1 != b.value != :value_2`. The result was a ProgrammingError, since my Postgres was unable to compare a boolean (`a.value != :value_1`) to an integer (`b.value`). I hoped the compiled SQL would reflect the parenthetical grouping of the SQLA expression above.

As it turned out, I was able to work around via `~((a.flag != 0) == (b.flag != 0))`, which compiled as expected. However it seems to me that SQLA should not consider the `eq` and `ne` operators to be associative. `(a = b) = c` does in fact mean something quite different from `a = (b = c)`; likewise, `(a != b) != c` is not the same as `a != (b != c)`. And furthermore, even if `a = b = c` is technically well-formed and usable SQL output (i.e. even if `c` is boolean), it is not exactly the height of human readability; if I came across such in a code review, I'd probably recommend parentheses for readability.

Have I missed something? Is there some situation where `a = b = c` or `a != b != c` is genuinely desirable?

If not, I propose the attached change.