### PR TITLE
Fixed the persistent_to_deleted event

### DIFF
--- a/lib/sqlalchemy/orm/session.py
+++ b/lib/sqlalchemy/orm/session.py
@@ -1643,13 +1643,14 @@ class Session(_SessionClassMethods):
                 self.transaction._deleted[state] = True
 
             self.identity_map.safe_discard(state)
+            obj = state.obj()
             self._deleted.pop(state, None)
             state._deleted = True
             # can't call state._detach() here, because this state
             # is still in the transaction snapshot and needs to be
             # tracked as part of that
             if persistent_to_deleted is not None:
-                persistent_to_deleted(self, state.obj())
+                persistent_to_deleted(self, obj)
 
     def add(self, instance, _warn=True):
         """Place an object in the ``Session``.


### PR DESCRIPTION
Got a reference of the deleted instance before remove it from state.
The old code always send a None instead the instance.