### PR TITLE
Replace uses of the phrase "comprised of" in docs

### DIFF
--- a/doc/build/core/schema.rst
+++ b/doc/build/core/schema.rst
@@ -10,7 +10,7 @@ This section references SQLAlchemy **schema metadata**, a comprehensive system o
 database schemas.
 
 The core of SQLAlchemy's query and object mapping operations are supported by
-*database metadata*, which is comprised of Python objects that describe tables
+*database metadata*, which is composed of Python objects that describe tables
 and other schema-level objects. These objects are at the core of three major
 types of operations - issuing CREATE and DROP statements (known as *DDL*),
 constructing SQL queries, and expressing information about structures that

--- a/doc/build/orm/nonstandard_mappings.rst
+++ b/doc/build/orm/nonstandard_mappings.rst
@@ -9,7 +9,7 @@ Mapping a Class against Multiple Tables
 
 Mappers can be constructed against arbitrary relational units (called
 *selectables*) in addition to plain tables. For example, the :func:`~.expression.join`
-function creates a selectable unit comprised of
+function creates a selectable unit composed of
 multiple tables, complete with its own composite primary key, which can be
 mapped in the same way as a :class:`.Table`::
 


### PR DESCRIPTION
Turns out 'comprised of' isn't grammatically correct. 

> American lexicographer Bryan A. Garner writes that "The phrase is comprised of is always wrong and should be replaced by either is composed of or comprises."

https://en.wikipedia.org/wiki/Comprised_of
