### PR TITLE
Remove some legacy dead code from the declared_attr logic

### DIFF
--- a/lib/sqlalchemy/ext/declarative/api.py
+++ b/lib/sqlalchemy/ext/declarative/api.py
@@ -181,9 +181,6 @@ class declared_attr(interfaces._MappedAttribute, property):
                     "non-mapped class %s" %
                     (desc.fget.__name__, cls.__name__))
             return desc.fget(cls)
-
-        if reg is None:
-            return desc.fget(cls)
         elif desc in reg:
             return reg[desc]
         else:


### PR DESCRIPTION
The second 'if' condition was never called because the original
condition always returns.