### PR TITLE
Remove unused and dysfunctional method

### DIFF
--- a/lib/sqlalchemy/engine/base.py
+++ b/lib/sqlalchemy/engine/base.py
@@ -1458,9 +1458,6 @@ class Connection(Connectable):
         else:
             util.reraise(*exc_info)
 
-    def default_schema_name(self):
-        return self.engine.dialect.get_default_schema_name(self)
-
     def transaction(self, callable_, *args, **kwargs):
         """Execute the given function within a transaction boundary.
 


### PR DESCRIPTION
The method `engine.base.Connection.default_schema_name` is broken since 4b532e2 (this was when `engine.dialect.get_default_schema_name` was replaced with `engine.dialect.default_schema_name`).

I don't see a point in fixing it since the method is actually nowhere called anyway (which is probably why nobody noticed that it's broken for the past 7 years already :smiley:). I therefore suggest just removing it.