### PR TITLE
Better hide engine password

### DIFF
--- a/lib/sqlalchemy/engine/threadlocal.py
+++ b/lib/sqlalchemy/engine/threadlocal.py
@@ -135,4 +135,4 @@ class TLEngine(base.Engine):
             self._connections.trans = []
 
     def __repr__(self):
-        return 'TLEngine(%s)' % str(self.url)
+        return 'TLEngine(%r)' % self.url

--- a/lib/sqlalchemy/sql/schema.py
+++ b/lib/sqlalchemy/sql/schema.py
@@ -3811,8 +3811,8 @@ class MetaData(SchemaItem):
                     s = schema and (" schema '%s'" % schema) or ''
                     raise exc.InvalidRequestError(
                         'Could not reflect: requested table(s) not available '
-                        'in %s%s: (%s)' %
-                        (bind.engine.url, s, ', '.join(missing)))
+                        'in %r%s: (%s)' %
+                        (bind.engine, s, ', '.join(missing)))
                 load = [name for name in only if extend_existing or
                         name not in current]
 


### PR DESCRIPTION
Avoid putting engine password in the exception message in `MetaData.reflect` (since exception messages often appear in logs).
Use the same redacted `__repr__` implementation in `TLEngine` as in its base class `Engine`