### PR TITLE
Multiple Join Paths in automap

### DIFF
--- a/lib/sqlalchemy/ext/automap.py
+++ b/lib/sqlalchemy/ext/automap.py
@@ -584,7 +584,7 @@ def name_for_collection_relationship(
 
     The default implementation is::
 
-        return referred_cls.__name__.lower() + "_collection"
+        return referred_cls.__name__.lower() + '_'+constraint.table.name.lower() + "_collection"
 
     Alternate implementations
     can be specified using the
@@ -601,7 +601,7 @@ def name_for_collection_relationship(
      inspected to produce this relationship.
 
     """
-    return referred_cls.__name__.lower() + "_collection"
+    return referred_cls.__name__.lower() + '_'+constraint.table.name.lower() + "_collection"
 
 
 def generate_relationship(


### PR DESCRIPTION
I make a pull request because bitbucket sqlachemy seems broken and there is no issue here.
The way automap names collections relationships makes impossible to have more than one foreign key path between to tables.
This can issue in having an erratic behavior as the <referred_cls.__name__.lower() + "_collection"> name can to one or another foreign key path.
So my solution is to add the name of the foreign constraint table to collection name, so there is no more confusion.