### PR TITLE
MSSQL: no lastrowid when no rows were inserted

### DIFF
--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -1052,7 +1052,7 @@ class MSExecutionContext(default.DefaultExecutionContext):
                                      self)
             # fetchall() ensures the cursor is consumed without closing it
             row = self.cursor.fetchall()[0]
-            self._lastrowid = int(row[0])
+            self._lastrowid = int(row[0]) if row[0] else None
 
         if (self.isinsert or self.isupdate or self.isdelete) and \
                 self.compiled.returning:

--- a/lib/sqlalchemy/dialects/mssql/pyodbc.py
+++ b/lib/sqlalchemy/dialects/mssql/pyodbc.py
@@ -241,7 +241,7 @@ class MSExecutionContext_pyodbc(MSExecutionContext):
                     # so we need to just keep flipping
                     self.cursor.nextset()
 
-            self._lastrowid = int(row[0])
+            self._lastrowid = int(row[0]) if row[0] else None
         else:
             super(MSExecutionContext_pyodbc, self).post_exec()
 

--- a/lib/sqlalchemy/dialects/mssql/zxjdbc.py
+++ b/lib/sqlalchemy/dialects/mssql/zxjdbc.py
@@ -42,7 +42,7 @@ class MSExecutionContext_zxjdbc(MSExecutionContext):
                     break
                 except self.dialect.dbapi.Error:
                     self.cursor.nextset()
-            self._lastrowid = int(row[0])
+            self._lastrowid = int(row[0]) if row[0] else None
 
         if (self.isinsert or self.isupdate or self.isdelete) and \
                 self.compiled.returning:


### PR DESCRIPTION
When using sqlalchemy core, if an INSERT statement results in no rows being inserted, both `SCOPE_IDENTITY()` and `@@IDENTITY` return NULL.

This results in the following error:
```
File "sqlalchemy/dialects/mssql/base.py", line 1055, in post_exec
    self._lastrowid = int(row[0])
TypeError: int() argument must be a string, a bytes-like object or a number, 
not 'NoneType'
```
Example situation where an INSERT statement results in no rows inserted. The target table has an `IDENTITY()` primary key column that auto increments.

```python
sub = source.select().where(
            ~source.c.secondary_key.in_(select([target.c.secondary_key])))
insert = target.insert().from_select(source.columns, sub)
```
This results in a query like:
```sql
INSERT INTO dbo.target (secondary_key, other_column) 
SELECT dbo.source.secondary_key, dbo.source.other_column FROM source 
WHERE dbo.source.secondary_key NOT IN (SELECT dbo.target.secondary_key 
FROM dbo.target)
```
When the source and target tables both contain the same secondary_key, this results in 0 rows inserted, so the post_exec query returns None, causing the TypeError.