### PR TITLE
Correct pytest deprecation warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ exclude = ^examples
 first-package-wins = true
 where = test
 
-[pytest]
+[tool:pytest]
 addopts= --tb native -v -r fxX --maxfail=25
 python_files=test/*test_*.py
 


### PR DESCRIPTION
WC1 None [pytest] section in setup.cfg files is deprecated, use [tool:pytest] instead.