### PR TITLE
Fix/no autoflush context manager

### DIFF
--- a/lib/sqlalchemy/orm/session.py
+++ b/lib/sqlalchemy/orm/session.py
@@ -1354,8 +1354,10 @@ class Session(_SessionClassMethods):
         """
         autoflush = self.autoflush
         self.autoflush = False
-        yield self
-        self.autoflush = autoflush
+        try:
+            yield self
+        finally:
+            self.autoflush = autoflush
 
     def _autoflush(self):
         if self.autoflush and not self._flushing:

--- a/test/orm/test_session.py
+++ b/test/orm/test_session.py
@@ -311,6 +311,7 @@ class SessionStateTest(_fixtures.FixtureTest):
         u = User()
         u.name = 'ed'
         sess.add(u)
+
         def go(obj):
             assert u not in sess.query(User).all()
         testing.run_as_contextmanager(sess.no_autoflush, go)

--- a/test/orm/test_session.py
+++ b/test/orm/test_session.py
@@ -1,3 +1,4 @@
+import pytest
 from sqlalchemy.testing import eq_, assert_raises, \
     assert_raises_message, assertions
 from sqlalchemy.testing.util import gc_collect
@@ -18,8 +19,6 @@ from sqlalchemy.testing import fixtures
 from test.orm import _fixtures
 from sqlalchemy import event, ForeignKey
 from sqlalchemy.util.compat import inspect_getargspec
-
-import pytest
 
 class ExecutionTest(_fixtures.FixtureTest):
     run_inserts = None

--- a/test/orm/test_session.py
+++ b/test/orm/test_session.py
@@ -1,4 +1,3 @@
-import pytest
 from sqlalchemy.testing import eq_, assert_raises, \
     assert_raises_message, assertions
 from sqlalchemy.testing.util import gc_collect
@@ -326,8 +325,14 @@ class SessionStateTest(_fixtures.FixtureTest):
                 1 / 0
             except ZeroDivisionError:
                 raise
-        with pytest.raises(ZeroDivisionError):
-            testing.run_as_contextmanager(sess.no_autoflush, go)
+
+        assert_raises(
+            ZeroDivisionError,
+            testing.run_as_contextmanager,
+            sess.no_autoflush,
+            go
+        )
+
         assert sess.autoflush == True
 
     def test_deleted_flag(self):


### PR DESCRIPTION
This PR wraps the `yield` in `sqlalchemy.lib.orm.session.Session.no_autoflush` in a `try/finally` per https://docs.python.org/3/library/contextlib.html#contextlib.closing. 

Currently, if there is a `raise` (or error I assume) in the context manager, the session will return without closing the context. I.e. it will return with `autoflush = False`. Wrapping it in a `try/finally` fixes that.
