### PR TITLE
Add support for prefixes on CREATE INDEX statements in MySQL

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -391,6 +391,22 @@ BLOB.
 .. versionadded:: 0.8.2 ``mysql_length`` may now be specified as a dictionary
    for use with composite indexes.
 
+Index Prefixes
+~~~~~~~~~~~~~
+
+MySQL storage engines permit you to specify an index prefix when creating
+an index. SQLAlchemy provides this feature via the
+``mysql_prefix`` parameter on :class:`.Index`::
+
+    Index('my_index', my_table.c.data, mysql_prefix='FULLTEXT')
+
+The value passed to the keyword argument will be simply passed through to the
+underlying CREATE INDEX, so it *must* be a valid index prefix for your MySQL storage engine.
+
+More information can be found at:
+
+http://dev.mysql.com/doc/refman/5.0/en/create-index.html
+
 Index Types
 ~~~~~~~~~~~~~
 
@@ -1039,6 +1055,11 @@ class MySQLDDLCompiler(compiler.DDLCompiler):
         text = "CREATE "
         if index.unique:
             text += "UNIQUE "
+
+        index_prefix = index.kwargs.get('mysql_prefix', None)
+        if index_prefix:
+          text += index_prefix + ' '
+
         text += "INDEX %s ON %s " % (name, table)
 
         length = index.dialect_options['mysql']['length']
@@ -1468,6 +1489,7 @@ class MySQLDialect(default.DefaultDialect):
         (sa_schema.Index, {
             "using": None,
             "length": None,
+            "prefix": None,
         })
     ]
 

--- a/test/dialect/mysql/test_compiler.py
+++ b/test/dialect/mysql/test_compiler.py
@@ -40,6 +40,14 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
         self.assert_compile(schema.CreateIndex(idx),
                             'CREATE INDEX test_idx1 ON testtbl (data)')
 
+    def test_create_index_with_prefix(self):
+        m = MetaData()
+        tbl = Table('testtbl', m, Column('data', String(255)))
+        idx = Index('test_idx1', tbl.c.data, mysql_length=10, mysql_prefix='FULLTEXT')
+
+        self.assert_compile(schema.CreateIndex(idx),
+                            'CREATE FULLTEXT INDEX test_idx1 ON testtbl (data(10))')
+
     def test_create_index_with_length(self):
         m = MetaData()
         tbl = Table('testtbl', m, Column('data', String(255)))


### PR DESCRIPTION
Adds a `mysql_prefix` argument on index creation, to allow for easy creation of a `FULLTEXT` or `SPACIAL` index in MySQL