### PR TITLE
Add oracle check constraints

### DIFF
--- a/lib/sqlalchemy/dialects/oracle/base.py
+++ b/lib/sqlalchemy/dialects/oracle/base.py
@@ -1617,7 +1617,7 @@ class OracleDialect(default.DefaultDialect):
                 'name': self.normalize_name(cons[0]),
                 'sqltext': cons[8],
             }
-            for cons in check_constraints
+            for cons in check_constraints]
 
 
 class _OuterJoinColumn(sql.ClauseElement):

--- a/lib/sqlalchemy/dialects/oracle/base.py
+++ b/lib/sqlalchemy/dialects/oracle/base.py
@@ -1440,8 +1440,8 @@ class OracleDialect(default.DefaultDialect):
             "\nrem.column_name AS remote_column,"\
             "\nrem.owner AS remote_owner,"\
             "\nloc.position as loc_pos,"\
-            "\nrem.position as rem_pos"\
-            "\nac.search_condition,"\
+            "\nrem.position as rem_pos,"\
+            "\nac.search_condition"\
             "\nFROM all_constraints%(dblink)s ac,"\
             "\nall_cons_columns%(dblink)s loc,"\
             "\nall_cons_columns%(dblink)s rem"\

--- a/test/requirements.py
+++ b/test/requirements.py
@@ -327,7 +327,8 @@ class DefaultRequirements(SuiteRequirements):
     def check_constraint_reflection(self):
         return fails_on_everything_except(
                     "postgresql",
-                    "sqlite"
+                    "sqlite",
+                    "oracle"
                 )
 
     @property


### PR DESCRIPTION
I added check constraints inspection in oracle dialect. looks like working fine.
I saw that in previous implemented dialects ex: postgresql column.constraints don't take any benefit of this, so you can only retrieve this values using inspector. So I just did the same.

I also still looking for some time to check the unique constraints inspection in oracle. It was not as straightforward as I thought.