### PR TITLE
Add new reserved words for MySQL 8.0 (beta).

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -676,6 +676,9 @@ RESERVED_WORDS = set(
 
      'generated', 'optimizer_costs', 'stored', 'virtual',  # 5.7
 
+     'admin', 'except', 'grouping', 'of', 'persist', 'recursive',
+        'role',  # 8.0
+
      ])
 
 AUTOCOMMIT_RE = re.compile(


### PR DESCRIPTION
Based on https://dev.mysql.com/doc/refman/8.0/en/keywords.html#table-keywords-new-8.0

I think there's little risk in adding them before MySQL 8.0 gets a first stable release. But feel free to disagree :)