### PR TITLE
Current Version Compare Doesn't Match Postgres 10devel

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -2281,7 +2281,7 @@ class PGDialect(default.DefaultDialect):
         v = connection.execute("select version()").scalar()
         m = re.match(
             r'.*(?:PostgreSQL|EnterpriseDB) '
-            r'(\d+)\.(\d+)(?:\.(\d+))?(?:\.\d+)?(?:devel)?',
+            r'(\d+)\.?(\d+)?(?:\.(\d+))?(?:\.\d+)?(?:devel)?',
             v)
         if not m:
             raise AssertionError(

--- a/test/dialect/postgresql/test_dialect.py
+++ b/test/dialect/postgresql/test_dialect.py
@@ -60,7 +60,10 @@ class MiscTest(fixtures.TestBase, AssertsExecutionResults, AssertsCompiledSQL):
                     '64-bit', (9, 1, 2)),
                 (
                     '[PostgreSQL 9.2.4 ] VMware vFabric Postgres 9.2.4.0 '
-                    'release build 1080137', (9, 2, 4))]:
+                    'release build 1080137', (9, 2, 4)),
+                (
+                    'PostgreSQL 10devel on x86_64-pc-linux-gnu'
+                    'compiled by gcc (GCC) 6.3.1 20170306, 64-bit', (10,))]:
             eq_(testing.db.dialect._get_server_version_info(mock_conn(string)),
                 version)
 


### PR DESCRIPTION
Current Dev version of Postgresql is 10, the version is "10devel" when built via current master branch. The current version comparisons errors on not being able to match.

`Could not determine version from string 'PostgreSQL 10devel on x86_64-pc-linux-gnu, compiled by gcc (GCC) 6.3.1 20170306, 64-bit'`

This pull requests adds a fix.