### PR TITLE
MySQL UTC_TIMESTAMP - add support for fsp argument

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -800,6 +800,10 @@ class MySQLCompiler(compiler.SQLCompiler):
         return "rand%s" % self.function_argspec(fn)
 
     def visit_utc_timestamp_func(self, fn, **kw):
+        if len(fn.clauses) == 1:
+            # Starting from MySQL 5.6.4 it's possible to specify a fractional seconds precision from 0 to 6.
+            # https://dev.mysql.com/doc/refman/5.6/en/date-and-time-functions.html#function_utc-timestamp
+            return "UTC_TIMESTAMP(%s)" % self.process(fn.clauses)
         return "UTC_TIMESTAMP"
 
     def visit_sysdate_func(self, fn, **kw):

--- a/test/dialect/mysql/test_compiler.py
+++ b/test/dialect/mysql/test_compiler.py
@@ -337,6 +337,10 @@ class SQLTest(fixtures.TestBase, AssertsCompiledSQL):
 
     def test_utc_timestamp(self):
         self.assert_compile(func.utc_timestamp(), "UTC_TIMESTAMP")
+        fsp = 3
+        self.assert_compile(func.utc_timestamp(fsp),
+                            "UTC_TIMESTAMP(%s)",
+                            params={'utc_timestamp_1': fsp})
 
     def test_sysdate(self):
         self.assert_compile(func.sysdate(), "SYSDATE()")


### PR DESCRIPTION
Starting from MySQL 5.6.4 it's possible to specify a fractional seconds precision from 0 to 6.
https://dev.mysql.com/doc/refman/5.6/en/date-and-time-functions.html#function_utc-timestamp