### PR TITLE
remove ambiguous line breakers to help sphinx identify code block

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -205,8 +205,7 @@ Most MySQL DBAPIs offer the option to set the client character set for
 a connection.   This is typically delivered using the ``charset`` parameter
 in the URL, such as::
 
-    e = create_engine("mysql+pymysql://scott:tiger@localhost/\
-test?charset=utf8")
+    e = create_engine("mysql+pymysql://scott:tiger@localhost/test?charset=utf8")
 
 This charset is the **client character set** for the connection.  Some
 MySQL DBAPIs will default this to a value such as ``latin1``, and some
@@ -224,8 +223,7 @@ that includes codepoints more than three bytes in size,
 this new charset is preferred, if supported by both the database as well
 as the client DBAPI, as in::
 
-    e = create_engine("mysql+pymysql://scott:tiger@localhost/\
-test?charset=utf8mb4")
+    e = create_engine("mysql+pymysql://scott:tiger@localhost/test?charset=utf8mb4")
 
 At the moment, up-to-date versions of MySQLdb and PyMySQL support the
 ``utf8mb4`` charset.   Other DBAPIs such as MySQL-Connector and OurSQL
@@ -2105,4 +2103,3 @@ class _DecodingRowProxy(object):
             return item.decode(self.charset)
         else:
             return item
-

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -205,7 +205,8 @@ Most MySQL DBAPIs offer the option to set the client character set for
 a connection.   This is typically delivered using the ``charset`` parameter
 in the URL, such as::
 
-    e = create_engine("mysql+pymysql://scott:tiger@localhost/test?charset=utf8")
+    e = create_engine(
+        "mysql+pymysql://scott:tiger@localhost/test?charset=utf8")
 
 This charset is the **client character set** for the connection.  Some
 MySQL DBAPIs will default this to a value such as ``latin1``, and some
@@ -223,7 +224,8 @@ that includes codepoints more than three bytes in size,
 this new charset is preferred, if supported by both the database as well
 as the client DBAPI, as in::
 
-    e = create_engine("mysql+pymysql://scott:tiger@localhost/test?charset=utf8mb4")
+    e = create_engine(
+        "mysql+pymysql://scott:tiger@localhost/test?charset=utf8mb4")
 
 At the moment, up-to-date versions of MySQLdb and PyMySQL support the
 ``utf8mb4`` charset.   Other DBAPIs such as MySQL-Connector and OurSQL
@@ -235,8 +237,8 @@ the MySQL schema and/or server configuration may be required.
 .. seealso::
 
     `The utf8mb4 Character Set \
-<http://dev.mysql.com/doc/refman/5.5/en/charset-unicode-utf8mb4.html>`_ - \
-in the MySQL documentation
+    <http://dev.mysql.com/doc/refman/5.5/en/charset-unicode-utf8mb4.html>`_ - \
+    in the MySQL documentation
 
 Unicode Encoding / Decoding
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -257,7 +259,8 @@ DBAPI's handling of unicode, such that it instead will return data of the
 ``str`` type or ``bytes`` type, with data in the configured charset::
 
     # connect while disabling the DBAPI's unicode encoding/decoding
-    e = create_engine("mysql+mysqldb://scott:tiger@localhost/test?charset=utf8&use_unicode=0")
+    e = create_engine(
+        "mysql+mysqldb://scott:tiger@localhost/test?charset=utf8&use_unicode=0")
 
 Current recommendations for modern DBAPIs are as follows:
 
@@ -406,7 +409,8 @@ storage engine.
 
 .. seealso::
 
-    `CREATE INDEX <http://dev.mysql.com/doc/refman/5.0/en/create-index.html>`_ - MySQL documentation
+    `CREATE INDEX <http://dev.mysql.com/doc/refman/5.0/en/create-index.html>`_ - \
+    MySQL documentation
 
 Index Types
 ~~~~~~~~~~~~~


### PR DESCRIPTION
As title. Fixing http://docs.sqlalchemy.org/en/latest/dialects/mysql.html#charset-selection.