### PR TITLE
Fix hyperlink in doc

### DIFF
--- a/doc/build/core/type_basics.rst
+++ b/doc/build/core/type_basics.rst
@@ -36,7 +36,8 @@ particular type of Python data.  SQLAlchemy will choose the best
 database column type available on the target database when issuing a
 ``CREATE TABLE`` statement.  For complete control over which column
 type is emitted in ``CREATE TABLE``, such as ``VARCHAR`` see `SQL
-Standard Types`_ and the other sections of this chapter.
+Standard and Multiple Vendor Types`_ and the other sections of this
+chapter.
 
 .. autoclass:: BigInteger
    :members:


### PR DESCRIPTION
a80bb4e5aabc4850a202f3a4d114c543357e37d5 broke the hyperlink to the section "SQL Standard and Multiple Vendor Types".