### PR TITLE
fix modulo operator for postgres when using literal_binds=True

### DIFF
--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -1065,7 +1065,8 @@ class SQLCompiler(Compiled):
                 return self._generate_generic_binary(binary, opstring, **kw)
 
     def visit_mod_binary(self, binary, operator, **kw):
-        if self.preparer._double_percents:
+        if self.preparer._double_percents and \
+                not kw.get('literal_binds', False):
             return self.process(binary.left, **kw) + " %% " + \
                 self.process(binary.right, **kw)
         else:

--- a/test/sql/test_compiler.py
+++ b/test/sql/test_compiler.py
@@ -2720,6 +2720,15 @@ class SelectTest(fixtures.TestBase, AssertsCompiledSQL):
                       and_, ("a",), ("b",)
                       )
 
+    def test_literal_binds_with_mod_and_double_percents(self):
+        stmt = select([(table1.c.myid % 1).label('col')])
+        self.assert_compile(
+            stmt,
+            "SELECT mytable.myid % 1 AS col FROM mytable",
+            dialect='postgresql',
+            literal_binds=True,
+        )
+
 
 class UnsupportedTest(fixtures.TestBase):
 


### PR DESCRIPTION
The _double_percents flag caused the mod (%) operator to be rendered as %;
however, when using literal_binds=True, meaning we want to see the SQL as if we
had typed it manually, the compiler would still emit %%.