### PR TITLE
Fix typo in example code

### DIFF
--- a/doc/build/core/connections.rst
+++ b/doc/build/core/connections.rst
@@ -142,8 +142,8 @@ Or from the :class:`.Connection`, in which case the :class:`.Transaction` object
 is available as well::
 
     with connection.begin() as trans:
-        r1 = connection.execute(table1.select())
-        connection.execute(table1.insert(), col1=7, col2='this is some data')
+        r1 = trans.execute(table1.select())
+        trans.execute(table1.insert(), col1=7, col2='this is some data')
 
 .. _connections_nested_transactions:
 


### PR DESCRIPTION
The example for the transaction context manager has a typo where it calls `connection.execute` instead of `trans.execute` that results in the transaction not being rolled back if there is an error. The proposed change fixes this by calling `trans.execute`.