### PR TITLE
Fixed. when mysql fetch result None crash

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -1672,14 +1672,19 @@ class MySQLDialect(default.DefaultDialect):
     def _compat_fetchone(self, rp, charset=None):
         """Proxy a result row to smooth over MySQL-Python driver
         inconsistencies."""
-
-        return _DecodingRowProxy(rp.fetchone(), charset)
+        data = rp.fetchone()
+        if data:
+            return _DecodingRowProxy(data, charset)
+        return None
 
     def _compat_first(self, rp, charset=None):
         """Proxy a result row to smooth over MySQL-Python driver
         inconsistencies."""
 
-        return _DecodingRowProxy(rp.first(), charset)
+        data = rp.first()
+        if data:
+            return _DecodingRowProxy(data, charset)
+        return None
 
     def _extract_error_code(self, exception):
         raise NotImplementedError()


### PR DESCRIPTION
when mysql fetch result is None __getitem__ crash
```python
    item = self.rowproxy[index]
TypeError: 'NoneType' object has no attribute '__getitem__'
```