### PR TITLE
reflected comments now not overriden by _init_existing function

### DIFF
--- a/lib/sqlalchemy/sql/schema.py
+++ b/lib/sqlalchemy/sql/schema.py
@@ -593,6 +593,9 @@ class Table(DialectKWArgs, SchemaItem, TableClause):
                 raise exc.ArgumentError(
                     "Can't redefine 'quote' or 'quote_schema' arguments")
 
+        if 'comment' in kwargs:
+            self.comment = kwargs.pop('comment', None)
+
         if 'info' in kwargs:
             self.info = kwargs.pop('info')
 

--- a/lib/sqlalchemy/sql/schema.py
+++ b/lib/sqlalchemy/sql/schema.py
@@ -596,8 +596,6 @@ class Table(DialectKWArgs, SchemaItem, TableClause):
         if 'info' in kwargs:
             self.info = kwargs.pop('info')
 
-        self.comment = kwargs.pop('comment', None)
-
         if autoload:
             if not autoload_replace:
                 # don't replace columns already present.

--- a/test/engine/test_reflection.py
+++ b/test/engine/test_reflection.py
@@ -1055,6 +1055,10 @@ class ReflectionTest(fixtures.TestBase, ComparesTables):
         eq_(t2.comment, 't1 comment')
         eq_(t2.c.id.comment, 'c1 comment')
 
+        t3 = Table('sometable', m2, extend_existing=True)
+        eq_(t3.comment, 't1 comment')
+        eq_(t3.c.id.comment, 'c1 comment')
+
     @testing.requires.check_constraint_reflection
     @testing.provide_metadata
     def test_check_constraint_reflection(self):


### PR DESCRIPTION
_init_existing https://github.com/zzzeek/sqlalchemy/blob/master/lib/sqlalchemy/sql/schema.py#L599
Was overriding table.comment value set on
 _reflect_table_comment https://github.com/zzzeek/sqlalchemy/blob/master/lib/sqlalchemy/engine/reflection.py#L869

So reflected table comments were first correctly set to the table through _reflect_table_comment but then immediatly set again to None by _init_existing function.

This lead to be unable to retrieve table comments like: SomeEntity.__table__.comment because was always returning None.