### PR TITLE
Fix import of nullsfirst() and nullslast() in sample code

### DIFF
--- a/lib/sqlalchemy/__init__.py
+++ b/lib/sqlalchemy/__init__.py
@@ -38,6 +38,8 @@ from .sql import (
     modifier,
     not_,
     null,
+    nullsfirst,
+    nullslast,
     or_,
     outerjoin,
     outparam,

--- a/lib/sqlalchemy/sql/__init__.py
+++ b/lib/sqlalchemy/sql/__init__.py
@@ -53,6 +53,8 @@ from .expression import (
     modifier,
     not_,
     null,
+    nullsfirst,
+    nullslast,
     or_,
     outerjoin,
     outparam,


### PR DESCRIPTION
The same code imports the two functions from the toplevel `sqlalchemy` module: dunno if there is a missing import to expose them there, or if it is instead a glitch in the documentation; in the latter case, this should fix it :-)