### PR TITLE
Fix MSSQL TIMESTAMP type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ sqlnet.log
 /test.py
 /.cache/
 *.sw[o,p]
+test_schema.db

--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -617,12 +617,17 @@ from ... import engine
 from ...engine import reflection, default
 from ... import types as sqltypes
 from ...types import INTEGER, BIGINT, SMALLINT, DECIMAL, NUMERIC, \
-    FLOAT, TIMESTAMP, DATETIME, DATE, BINARY,\
+    FLOAT, DATETIME, DATE, BINARY,\
     TEXT, VARCHAR, NVARCHAR, CHAR, NCHAR
 
 
 from ...util import update_wrapper
 from . import information_schema as ischema
+
+
+# The mssql TIMESTAMP value is *not* the ANSI SQL TIMESTAMP type
+# https://msdn.microsoft.com/en-us/library/ms182776%28v=SQL.90%29.aspx
+TIMESTAMP = BINARY
 
 # http://sqlserverbuilds.blogspot.com/
 MS_2016_VERSION = (13,)

--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -625,10 +625,6 @@ from ...util import update_wrapper
 from . import information_schema as ischema
 
 
-# The mssql TIMESTAMP value is *not* the ANSI SQL TIMESTAMP type
-# https://msdn.microsoft.com/en-us/library/ms182776%28v=SQL.90%29.aspx
-TIMESTAMP = BINARY
-
 # http://sqlserverbuilds.blogspot.com/
 MS_2016_VERSION = (13,)
 MS_2014_VERSION = (12,)
@@ -667,6 +663,20 @@ RESERVED_WORDS = set(
      'varying', 'view', 'waitfor', 'when', 'where', 'while', 'with',
      'writetext',
      ])
+
+
+class TIMESTAMP(sqltypes.BINARY):
+    """The MSSQL TIMESTAMP type is a *binary* type and is different from the
+    TIMESTAMP data type defined in the SQL-2003 standard. The SQL-2003 TIMESTAMP
+    data type is equivalent to the MSSQL DATETIME data type.
+
+    A nonnullable timestamp column is semantically equivalent to a BINARY(8)
+    column. A nullable timestamp column is semantically equivalent to a
+    VARBINARY(8) column.
+
+    :ref: https://msdn.microsoft.com/en-us/library/ms182776%28v=SQL.90%29.aspx
+    """
+    pass
 
 
 class REAL(sqltypes.REAL):


### PR DESCRIPTION
The [`mssql.TIMESTMAP`](https://msdn.microsoft.com/en-us/library/ms182776%28v=SQL.90%29.aspx) type isn't equivalent to the ANSI SQL `TIMESTAMP` type but is instead a *binary* counter.

From the docs:
> *The Transact-SQL timestamp data type is different from the timestamp data type defined in the SQL-2003 standard. The SQL-2003 timestamp data type is equivalent to the Transact-SQL datetime data type.*

> *A nonnullable timestamp column is semantically equivalent to a binary(8) column. A nullable timestamp column is semantically equivalent to a varbinary(8) column.*