### PR TITLE
Fix noseplugin to accept `zeroarg_callback` for `--dbs` option

### DIFF
--- a/lib/sqlalchemy/testing/plugin/noseplugin.py
+++ b/lib/sqlalchemy/testing/plugin/noseplugin.py
@@ -41,7 +41,7 @@ class NoseSQLAlchemy(Plugin):
         opt = parser.add_option
 
         def make_option(name, **kw):
-            callback_ = kw.pop("callback", None)
+            callback_ = kw.pop("callback", None) or kw.pop("zeroarg_callback", None)
             if callback_:
                 def wrap_(option, opt_str, value, parser):
                     callback_(opt_str, value, parser)


### PR DESCRIPTION
`./sqla_nose.py --dbs`  works fine with zero arguments and does not need special treatment as in pytestplugin. So `zeroarg_callback` should be treated as `callback`.

Without this change nose tests fail with:
```
$ ./sqla_nose.py
Traceback (most recent call last):
  File "./sqla_nose.py", line 33, in <module>
    nose.main(addplugins=[NoseSQLAlchemy()])
  File "/home/ishcherb/test/sqlalchemy/venv/lib/python2.7/site-packages/nose/core.py", line 121, in __init__
    **extra_args)
  File "/usr/lib64/python2.7/unittest/main.py", line 94, in __init__
    self.parseArgs(argv)
  File "/home/ishcherb/test/sqlalchemy/venv/lib/python2.7/site-packages/nose/core.py", line 145, in parseArgs
    self.config.configure(argv, doc=self.usage())
  File "/home/ishcherb/test/sqlalchemy/venv/lib/python2.7/site-packages/nose/config.py", line 281, in configure
    options, args = self._parseArgs(argv, cfg_files)
  File "/home/ishcherb/test/sqlalchemy/venv/lib/python2.7/site-packages/nose/config.py", line 268, in _parseArgs
    self.getParser(), self.configSection, file_error=warn_sometimes)
  File "/home/ishcherb/test/sqlalchemy/venv/lib/python2.7/site-packages/nose/config.py", line 591, in getParser
    self.pluginOpts(parser)
  File "/home/ishcherb/test/sqlalchemy/venv/lib/python2.7/site-packages/nose/config.py", line 602, in pluginOpts
    self.plugins.addOptions(parser, self.env)
  File "/home/ishcherb/test/sqlalchemy/venv/lib/python2.7/site-packages/nose/plugins/manager.py", line 99, in __call__
    return self.call(*arg, **kw)
  File "/home/ishcherb/test/sqlalchemy/venv/lib/python2.7/site-packages/nose/plugins/manager.py", line 167, in simple
    result = meth(*arg, **kw)
  File "/home/ishcherb/test/sqlalchemy/venv/lib/python2.7/site-packages/nose/plugins/base.py", line 52, in addOptions
    self.add_options(parser, env)
  File "/home/ishcherb/test/sqlalchemy/venv/lib/python2.7/site-packages/nose/plugins/base.py", line 68, in add_options
    self.options(parser, env)
  File "./lib/sqlalchemy/testing/plugin/noseplugin.py", line 51, in options
    plugin_base.setup_options(make_option)
  File "./lib/sqlalchemy/testing/plugin/plugin_base.py", line 58, in setup_options
    help="List available prefab dbs")
  File "./lib/sqlalchemy/testing/plugin/noseplugin.py", line 49, in make_option
    opt(name, **kw)
  File "/usr/lib64/python2.7/optparse.py", line 1013, in add_option
    option = self.option_class(*args, **kwargs)
  File "/usr/lib64/python2.7/optparse.py", line 570, in __init__
    self._set_attrs(attrs)
  File "/usr/lib64/python2.7/optparse.py", line 625, in _set_attrs
    self)
optparse.OptionError: option --dbs: invalid keyword arguments: zeroarg_callback

```