### PR TITLE
Implement DELETE ... USING

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -1102,6 +1102,21 @@ class MySQLCompiler(compiler.SQLCompiler):
                            extra_froms, from_hints, **kw):
         return None
 
+    def delete_using_clause(self, delete_stmt, from_table,
+                            usings, from_hints, **kw):
+        text = "USING "
+        if from_table not in usings:
+            text += from_table._compiler_dispatch(self, asfrom=True,
+                                                  fromhints=from_hints,
+                                                  **kw)
+            text += ', '
+        text += ', '.join(
+            t._compiler_dispatch(self, asfrom=True, fromhints=from_hints,
+                                 **kw)
+            for t in usings
+        )
+        return text
+
 
 class MySQLDDLCompiler(compiler.DDLCompiler):
     def get_column_specification(self, column, **kw):

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -691,6 +691,7 @@ output::
 
 import re
 import sys
+import itertools
 import json
 
 from ... import schema as sa_schema
@@ -1105,7 +1106,9 @@ class MySQLCompiler(compiler.SQLCompiler):
     def delete_using_clause(self, delete_stmt, from_table,
                             usings, from_hints, **kw):
         text = "USING "
-        if from_table not in usings:
+        if from_table not in itertools.chain.from_iterable(
+                i._from_objects for i in usings
+        ):
             text += from_table._compiler_dispatch(self, asfrom=True,
                                                   fromhints=from_hints,
                                                   **kw)

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -1636,6 +1636,13 @@ class PGCompiler(compiler.SQLCompiler):
 
         return 'ON CONFLICT %s DO UPDATE SET %s' % (target_text, action_text)
 
+    def delete_using_clause(self, delete_stmt, from_table, usings,
+                            from_hints, **kw):
+        return "USING " + ', '.join(
+            t._compiler_dispatch(self, asfrom=True,
+                                 fromhints=from_hints, **kw)
+            for t in usings)
+
 
 class PGDDLCompiler(compiler.DDLCompiler):
 

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -2234,16 +2234,12 @@ class SQLCompiler(Compiled):
 
     def delete_using_clause(self, delete_stmt, from_table, usings,
                             from_hints, **kw):
-        """Provide a hook to override the generation of an
+        """Provide a hook to implement the generation of an
         DELETE..USING clause.
 
-        MySQL overrides this.
-
+        Overridden by PostgreSQL and MySQL.
         """
-        return "USING " + ', '.join(
-            t._compiler_dispatch(self, asfrom=True,
-                                 fromhints=from_hints, **kw)
-            for t in usings)
+        return None
 
     def visit_delete(self, delete_stmt, asfrom=False, **kw):
         toplevel = not self.stack
@@ -2273,10 +2269,12 @@ class SQLCompiler(Compiled):
         text += table_text
 
         if delete_stmt._using_obj:
-            text += " " + self.delete_using_clause(
+            using_text = self.delete_using_clause(
                 delete_stmt, delete_stmt.table, delete_stmt._using_obj,
                 dialect_hints, **kw
             )
+            if using_text:
+                text += " " + using_text
 
         if delete_stmt._returning:
             if self.returning_precedes_values:

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -2239,7 +2239,9 @@ class SQLCompiler(Compiled):
 
         Overridden by PostgreSQL and MySQL.
         """
-        return None
+        raise NotImplementedError(
+            "Dialect does not implement DELETE .. USING clause."
+        )
 
     def visit_delete(self, delete_stmt, asfrom=False, **kw):
         toplevel = not self.stack

--- a/lib/sqlalchemy/sql/dml.py
+++ b/lib/sqlalchemy/sql/dml.py
@@ -828,6 +828,8 @@ class Delete(UpdateBase):
         else:
             self._whereclause = None
 
+        self._using_obj = None
+
         self._validate_dialect_kwargs(dialect_kw)
 
     def get_children(self, **kwargs):
@@ -845,6 +847,13 @@ class Delete(UpdateBase):
                                      _literal_as_text(whereclause))
         else:
             self._whereclause = _literal_as_text(whereclause)
+
+    @_generative
+    def using(self, *fromclauses):
+        """Add the given USING clause to a newly returned delete construct."""
+        self._using_obj = util.OrderedSet(
+            _interpret_as_from(fromclause) for fromclause in fromclauses
+        )
 
     def _copy_internals(self, clone=_clone, **kw):
         # TODO: coverage

--- a/lib/sqlalchemy/sql/dml.py
+++ b/lib/sqlalchemy/sql/dml.py
@@ -850,7 +850,11 @@ class Delete(UpdateBase):
 
     @_generative
     def using(self, *fromclauses):
-        """Add the given USING clause to a newly returned delete construct."""
+        """Add the given USING clause to a newly returned delete construct.
+
+        The USING clause can be used in PostgreSQL and MySQL to add tables
+        to use in the WHERE clause.
+        """
         self._using_obj = util.OrderedSet(
             _interpret_as_from(fromclause) for fromclause in fromclauses
         )

--- a/test/dialect/mysql/test_compiler.py
+++ b/test/dialect/mysql/test_compiler.py
@@ -712,6 +712,15 @@ class SQLTest(fixtures.TestBase, AssertsCompiledSQL):
             'DELETE FROM a1 USING t1 as a1, t2'
         )
 
+    def test_delete_using_with_join(self):
+        t1 = table('t1', column('x'))
+        t2 = table('t2', column('y'))
+        self.assert_compile(
+            sql.delete(t1).
+            using(t2.join(t1, onclause=t2.c.y == t1.c.x)),
+            'DELETE FROM t1 USING t2 JOIN t1 ON t2.y = t1.x'
+        )
+
 
 class InsertOnDuplicateTest(fixtures.TestBase, AssertsCompiledSQL):
     __dialect__ = mysql.dialect()

--- a/test/dialect/mysql/test_compiler.py
+++ b/test/dialect/mysql/test_compiler.py
@@ -691,6 +691,19 @@ class SQLTest(fixtures.TestBase, AssertsCompiledSQL):
             "t1 FULL OUTER JOIN t2 ON t1.x = t2.y"
         )
 
+    def test_delete_using(self):
+        t1 = table('t1', column('x'))
+        t2 = table('t2', column('y'))
+
+        self.assert_compile(
+            t1.delete().using(t2),
+            'DELETE FROM t1 USING t1, t2'
+        )
+        self.assert_compile(
+            t1.delete().using(t1, t2),
+            'DELETE FROM t1 USING t1, t2'
+        )
+
 
 class InsertOnDuplicateTest(fixtures.TestBase, AssertsCompiledSQL):
     __dialect__ = mysql.dialect()

--- a/test/dialect/mysql/test_compiler.py
+++ b/test/dialect/mysql/test_compiler.py
@@ -704,6 +704,14 @@ class SQLTest(fixtures.TestBase, AssertsCompiledSQL):
             'DELETE FROM t1 USING t1, t2'
         )
 
+    def test_delete_using_with_alias(self):
+        t1 = table('t1', column('x'))
+        t2 = table('t2', column('y'))
+        self.assert_compile(
+            sql.delete(t1.alias('a1')).using(t2),
+            'DELETE FROM a1 USING t1 as a1, t2'
+        )
+
 
 class InsertOnDuplicateTest(fixtures.TestBase, AssertsCompiledSQL):
     __dialect__ = mysql.dialect()

--- a/test/dialect/mysql/test_compiler.py
+++ b/test/dialect/mysql/test_compiler.py
@@ -718,7 +718,7 @@ class SQLTest(fixtures.TestBase, AssertsCompiledSQL):
         self.assert_compile(
             sql.delete(t1).
             using(t2.join(t1, onclause=t2.c.y == t1.c.x)),
-            'DELETE FROM t1 USING t2 JOIN t1 ON t2.y = t1.x'
+            'DELETE FROM t1 USING t2 INNER JOIN t1 ON t2.y = t1.x'
         )
 
 

--- a/test/dialect/postgresql/test_compiler.py
+++ b/test/dialect/postgresql/test_compiler.py
@@ -1091,6 +1091,16 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             "FROM table1 AS foo"
         )
 
+    def test_delete_using(self):
+        table1 = table('mytable', column('x'))
+        table2 = table('myothertable', column('y'))
+        self.assert_compile(delete(table1).using(table2),
+                            'DELETE FROM mytable USING myothertable')
+        self.assert_compile(delete(table1).using(table2,
+                                                 table1.alias('notmytable')),
+                            'DELETE FROM mytable USING myothertable, '
+                            'mytable AS notmytable')
+
 
 class InsertOnConflictTest(fixtures.TestBase, AssertsCompiledSQL):
     __dialect__ = postgresql.dialect()

--- a/test/sql/test_delete.py
+++ b/test/sql/test_delete.py
@@ -99,3 +99,12 @@ class DeleteTest(_DeleteTestBase, fixtures.TablesTest, AssertsCompiledSQL):
                             'FROM myothertable '
                             'WHERE myothertable.otherid = mytable.myid'
                             ')')
+
+    def test_using(self):
+        table1, table2 = self.tables.mytable, self.tables.myothertable
+        self.assert_compile(delete(table1).using(table2),
+                            'DELETE FROM mytable USING myothertable')
+        self.assert_compile(delete(table1).using(table2,
+                                                 table1.alias('notmytable')),
+                            'DELETE FROM mytable USING myothertable, '
+                            'mytable AS notmytable')

--- a/test/sql/test_delete.py
+++ b/test/sql/test_delete.py
@@ -99,12 +99,3 @@ class DeleteTest(_DeleteTestBase, fixtures.TablesTest, AssertsCompiledSQL):
                             'FROM myothertable '
                             'WHERE myothertable.otherid = mytable.myid'
                             ')')
-
-    def test_using(self):
-        table1, table2 = self.tables.mytable, self.tables.myothertable
-        self.assert_compile(delete(table1).using(table2),
-                            'DELETE FROM mytable USING myothertable')
-        self.assert_compile(delete(table1).using(table2,
-                                                 table1.alias('notmytable')),
-                            'DELETE FROM mytable USING myothertable, '
-                            'mytable AS notmytable')


### PR DESCRIPTION
This PR implements the DELETE ... USING feature for both [Postgresql](https://www.postgresql.org/docs/current/static/sql-delete.html) and [mysql](https://dev.mysql.com/doc/refman/5.7/en/delete.html) as mentioned here: https://bitbucket.org/zzzeek/sqlalchemy/issues/959/support-mysql-delete-from-join-postgresql

For mysql there are some cases that do not work right now:
- If the table to delete from is aliased
  - expected: `DELETE FROM a1 USING t1 AS a1, t2`
  - result: `DELETE FROM t1 AS a1 USING t1 AS a1, t2`
- If the table to delete from is in a join
  - expected: `DELETE FROM t1 USING t2 JOIN t1 ON t2.y = t1.x`
  - result `DELETE FROM t1 USING t1, t2 JOIN t1 ON t2.y = t1.x`

The easiest solution might be to just tell mysql users to explicitly add the delete from table to the using command. I added (failing) test cases for both the examples shown above.

I'd really love feedback and comments.