### PR TITLE
add order_by clause to make tests stable

### DIFF
--- a/lib/sqlalchemy/testing/suite/test_select.py
+++ b/lib/sqlalchemy/testing/suite/test_select.py
@@ -345,7 +345,7 @@ class ExpandingBoundInTest(fixtures.TablesTest):
         table = self.tables.some_table
 
         stmt = select([table.c.id]).where(
-            table.c.x.in_(bindparam('q', expanding=True)))
+            table.c.x.in_(bindparam('q', expanding=True))).order_by(table.c.id)
 
         self._assert_result(
             stmt,
@@ -358,7 +358,7 @@ class ExpandingBoundInTest(fixtures.TablesTest):
         table = self.tables.some_table
 
         stmt = select([table.c.id]).where(
-            tuple_(table.c.x, table.c.y).in_(bindparam('q', expanding=True)))
+            tuple_(table.c.x, table.c.y).in_(bindparam('q', expanding=True))).order_by(table.c.id)
 
         self._assert_result(
             stmt,


### PR DESCRIPTION
I observed test runs that failed on 'test_bound_in_scalar' due to arbitrary ordering of the result set. The assertion not only tests for the elements to be present, but also for the correct ordering. Hence, the proposal to add an order_by clause to the select statements.