### PR TITLE
Remove deprecation warnings mysql5 7 20

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -1720,7 +1720,7 @@ class MySQLDialect(default.DefaultDialect):
 
     def get_isolation_level(self, connection):
         cursor = connection.cursor()
-        if self.server_version_info < (5, 7, 30):
+        if self.server_version_info < (5, 7, 20):
             cursor.execute('SELECT @@tx_isolation')
         else:
             cursor.execute('SELECT @@transaction_isolation')

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -1720,7 +1720,10 @@ class MySQLDialect(default.DefaultDialect):
 
     def get_isolation_level(self, connection):
         cursor = connection.cursor()
-        cursor.execute('SELECT @@tx_isolation')
+        if self.server_version_info < (5, 7, 30):
+            cursor.execute('SELECT @@tx_isolation')
+        else:
+            cursor.execute('SELECT @@transaction_isolation')
         val = cursor.fetchone()[0]
         cursor.close()
         if util.py3k and isinstance(val, bytes):


### PR DESCRIPTION
@@tx_isolation is deprecated since MySQL 5.7.20 and will be removed in 8.0. This will check the version and issue correct check