### PR TITLE
Add multi-table delete statement

### DIFF
--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -1510,6 +1510,20 @@ class MSSQLCompiler(compiler.SQLCompiler):
                                  fromhints=from_hints, **kw)
             for t in [from_table] + extra_froms)
 
+    def delete_using_clause(self, update_stmt,
+                           from_table, extra_froms,
+                           **kw):
+        """Render the DELETE..FROM clause specific to MSSQL.
+
+        In MSSQL, if the DELETE statement involves an alias of the table to
+        be deleted, then the table itself must be added to the FROM list as
+        well. Otherwise, it is optional. Here, we add it regardless.
+
+        """
+        return "FROM " + ', '.join(
+            t._compiler_dispatch(self, asfrom=True, **kw)
+            for t in extra_froms)
+
 
 class MSSQLStrictCompiler(MSSQLCompiler):
 

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -1102,6 +1102,12 @@ class MySQLCompiler(compiler.SQLCompiler):
                            extra_froms, from_hints, **kw):
         return None
 
+    def delete_using_clause(self, delete_stmt,
+                            from_table, extra_froms,
+                            **kw):
+        return "USING " + ', '.join(t._compiler_dispatch(self, asfrom=True, **kw)
+                         for t in [from_table] + list(extra_froms))
+
 
 class MySQLDDLCompiler(compiler.DDLCompiler):
     def get_column_specification(self, column, **kw):

--- a/test/sql/test_delete.py
+++ b/test/sql/test_delete.py
@@ -99,3 +99,71 @@ class DeleteTest(_DeleteTestBase, fixtures.TablesTest, AssertsCompiledSQL):
                             'FROM myothertable '
                             'WHERE myothertable.otherid = mytable.myid'
                             ')')
+
+    def test_using(self):
+        table1, table2 = self.tables.mytable, self.tables.myothertable
+
+        self.assert_compile(table1.delete(table1.c.name == table2.c.othername),
+                            'DELETE FROM mytable '
+                            'USING myothertable '
+                            'WHERE mytable.name = myothertable.othername')
+
+    def test_using2(self):
+        table1, table2 = self.tables.mytable, self.tables.myothertable
+
+        table2_alias = table2.alias('a_third_table')
+
+        self.assert_compile(table1.delete(and_(table1.c.name == table2.c.othername, table1.c.name == table2_alias.c.othername)),
+                            'DELETE FROM mytable '
+                            'USING myothertable, myothertable AS a_third_table '
+                            'WHERE mytable.name = myothertable.othername '
+                            'AND mytable.name = a_third_table.othername')
+
+    def test_using_cte(self):
+        table1, table2 = self.tables.mytable, self.tables.myothertable
+
+        cte = select([table2.c.othername]).cte('some_cte')
+        self.assert_compile(table1.delete(table1.c.name == cte.c.othername),
+                            'WITH some_cte AS '
+                            '(SELECT myothertable.othername AS othername '
+                            'FROM myothertable) '
+                            'DELETE FROM mytable '
+                            'USING some_cte '
+                            'WHERE mytable.name = some_cte.othername')
+
+    def test_using_2cte_reference1(self):
+        table1, table2 = self.tables.mytable, self.tables.myothertable
+
+        cte1 = select([table2.c.othername], table2.c.othername != None).cte('first_cte')
+        cte2 = select([table2.c.otherid], cte1.c.othername == table2.c.othername).cte('second_cte')
+        self.assert_compile(table1.delete(table1.c.myid == cte2.c.otherid),
+                            'WITH first_cte AS '
+                            '(SELECT myothertable.othername AS othername '
+                            'FROM myothertable '
+                            'WHERE myothertable.othername IS NOT NULL), '
+                            'second_cte AS '
+                            '(SELECT myothertable.otherid AS otherid '
+                            'FROM myothertable, first_cte '
+                            'WHERE first_cte.othername = myothertable.othername) '
+                            'DELETE FROM mytable '
+                            'USING second_cte '
+                            'WHERE mytable.myid = second_cte.otherid')
+
+    def test_using_2cte_reference2(self):
+        table1, table2 = self.tables.mytable, self.tables.myothertable
+
+        cte1 = select([table2.c.othername], table2.c.othername != None).cte('first_cte')
+        cte2 = select([table2.c.otherid], cte1.c.othername == table2.c.othername).cte('second_cte')
+        self.assert_compile(table1.delete(and_(table1.c.myid == cte2.c.otherid, table1.c.name == cte1.c.othername)),
+                            'WITH first_cte AS '
+                            '(SELECT myothertable.othername AS othername '
+                            'FROM myothertable '
+                            'WHERE myothertable.othername IS NOT NULL), '
+                            'second_cte AS '
+                            '(SELECT myothertable.otherid AS otherid '
+                            'FROM myothertable, first_cte '
+                            'WHERE first_cte.othername = myothertable.othername) '
+                            'DELETE FROM mytable '
+                            'USING second_cte, first_cte '
+                            'WHERE mytable.myid = second_cte.otherid '
+                            'AND mytable.name = first_cte.othername')


### PR DESCRIPTION
This enables the ability to reference other tables, relations in the
WHERE clause, for databases that support it.  In PostgreSQL, this is
implemented with a DELETE FROM ... USING clause; in MySQL, a multi-table
delete statement; in SQL Server, a DELETE FROM ... FROM clause.