### PR TITLE
Allow for the database to produce a UUID instance

### DIFF
--- a/doc/build/core/custom_types.rst
+++ b/doc/build/core/custom_types.rst
@@ -163,7 +163,9 @@ binary in CHAR(16) if desired::
             if value is None:
                 return value
             else:
-                return uuid.UUID(value)
+                if not isinstance(value, uuid.UUID):
+                    value = uuid.UUID(value)
+                return value
 
 Marshal JSON Strings
 ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Some database adapters (specifically, pg8000) already produce a uuid.UUID()
instance for UUID columns. Account for this.

Specifically, see [*AttributeError: 'UUID' object has no attribute 'replace'* on Stack Overflow](https://stackoverflow.com/q/47429929/100297), where someone using pg8000 ran into this.