### PR TITLE
Fix greedy expanding bindparam

### DIFF
--- a/lib/sqlalchemy/engine/default.py
+++ b/lib/sqlalchemy/engine/default.py
@@ -779,7 +779,7 @@ class DefaultExecutionContext(interfaces.ExecutionContext):
             return replacement_expressions.pop(m.group(1))
 
         self.statement = re.sub(
-            r"\[EXPANDING_(.+)\]",
+            r"\[EXPANDING_(\w+)\]",
             process_expanding,
             self.statement
         )


### PR DESCRIPTION
There is an issue where if one is using multiple expanding bindparams, the regex would try to get everything from the first [ to the last ] in the statement instead of the the first ] it sees.