### PR TITLE
Use a callable to determine persisted enum values

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/enumerated.py
+++ b/lib/sqlalchemy/dialects/mysql/enumerated.py
@@ -126,6 +126,7 @@ class ENUM(sqltypes.NativeForEmulated, sqltypes.Enum, _EnumeratedValues):
 
         """
         kw.setdefault("validate_strings", impl.validate_strings)
+        kw.setdefault("values_callable", impl.values_callable)
         return cls(**kw)
 
     def _setup_for_values(self, values, objects, kw):

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -1257,6 +1257,7 @@ class ENUM(sqltypes.NativeForEmulated, sqltypes.Enum):
         kw.setdefault('inherit_schema', impl.inherit_schema)
         kw.setdefault('metadata', impl.metadata)
         kw.setdefault('_create_events', False)
+        kw.setdefault('values_callable', impl.values_callable)
         return cls(**kw)
 
     def create(self, bind=None, checkfirst=True):

--- a/lib/sqlalchemy/sql/sqltypes.py
+++ b/lib/sqlalchemy/sql/sqltypes.py
@@ -1348,7 +1348,7 @@ class Enum(Emulated, String, SchemaType):
             self.enum_class = enums[0]
             values_callable = kw.pop('values_callable', None)
             if values_callable:
-                self._values_callable = values_callable
+                self.values_callable = values_callable
                 values = values_callable(self.enum_class)
             else:
                 values = list(self.enum_class.__members__)

--- a/lib/sqlalchemy/sql/sqltypes.py
+++ b/lib/sqlalchemy/sql/sqltypes.py
@@ -1277,6 +1277,11 @@ class Enum(Emulated, String, SchemaType):
 
            .. versionadded:: 1.1.0b2
 
+        :param values_callable: A callable which will be passed the PEP-435 compliant
+            enumerated type and which will return a list of values. This allows for
+            alternate usages such as using the string value of an enum to be persisted
+            to the database instead of its name.
+
         """
         self._enum_init(enums, kw)
 
@@ -1341,8 +1346,13 @@ class Enum(Emulated, String, SchemaType):
 
         if len(enums) == 1 and hasattr(enums[0], '__members__'):
             self.enum_class = enums[0]
-            values = list(self.enum_class.__members__)
-            objects = [self.enum_class.__members__[k] for k in values]
+            values_callable = kw.pop('values_callable', None)
+            if values_callable:
+                self._values_callable = values_callable
+                values = values_callable(self.enum_class)
+            else:
+                values = list(self.enum_class.__members__)
+            objects = [self.enum_class.__members__[k] for k in self.enum_class.__members__]
             return values, objects
         else:
             self.enum_class = None

--- a/lib/sqlalchemy/sql/sqltypes.py
+++ b/lib/sqlalchemy/sql/sqltypes.py
@@ -1189,6 +1189,12 @@ class Enum(Emulated, String, SchemaType):
     indicated as integers, are **not** used; the value of each enum can
     therefore be any kind of Python object whether or not it is persistable.
 
+    This behavior can be customized by using the `values_callable` parameter.
+    `values_callable`, when used with a PEP-435-compliant enumerated class,
+    returns a list of values to use. Passing a trivial callable such as
+    ``lambda x: [e.value for e in x]`` allows the use of the string value
+    instead of the name as described above.
+
     .. versionadded:: 1.1 - support for PEP-435-style enumerated
        classes.
 
@@ -1282,6 +1288,8 @@ class Enum(Emulated, String, SchemaType):
             alternate usages such as using the string value of an enum to be persisted
             to the database instead of its name.
 
+            .. versionadded:: TODO
+
         """
         self._enum_init(enums, kw)
 
@@ -1302,6 +1310,7 @@ class Enum(Emulated, String, SchemaType):
         """
         self.native_enum = kw.pop('native_enum', True)
         self.create_constraint = kw.pop('create_constraint', True)
+        self.values_callable = kw.pop('values_callable', None)
 
         values, objects = self._parse_into_values(enums, kw)
         self._setup_for_values(values, objects, kw)
@@ -1346,10 +1355,8 @@ class Enum(Emulated, String, SchemaType):
 
         if len(enums) == 1 and hasattr(enums[0], '__members__'):
             self.enum_class = enums[0]
-            values_callable = kw.pop('values_callable', None)
-            if values_callable:
-                self.values_callable = values_callable
-                values = values_callable(self.enum_class)
+            if self.values_callable:
+                values = self.values_callable(self.enum_class)
             else:
                 values = list(self.enum_class.__members__)
             objects = [self.enum_class.__members__[k] for k in self.enum_class.__members__]

--- a/test/dialect/mysql/test_types.py
+++ b/test/dialect/mysql/test_types.py
@@ -13,7 +13,7 @@ from sqlalchemy import testing
 import datetime
 import decimal
 from sqlalchemy import types as sqltypes
-from enum import Enum as PyEnum
+from ...sql.test_types import EnumTest
 
 
 class TypesTest(fixtures.TestBase,
@@ -652,10 +652,6 @@ class EnumSetTest(
     __dialect__ = mysql.dialect()
     __backend__ = True
 
-    class StringEnum(PyEnum):
-        AMember = 'a'
-        BMember = 'b'
-
     @testing.provide_metadata
     def test_enum(self):
         """Exercise the ENUM type."""
@@ -677,8 +673,10 @@ class EnumSetTest(
             Column('e5', mysql.ENUM("a", "b")),
             Column('e5generic', Enum("a", "b")),
             Column('e6', mysql.ENUM("'a'", "b")),
-            Column('e7', mysql.ENUM(EnumSetTest.StringEnum, values_callable=lambda x: [e.value for e in x])),
-            Column('e8', mysql.ENUM(EnumSetTest.StringEnum))
+            Column('e7', mysql.ENUM(EnumTest.SomeEnum,
+                                    values_callable=EnumTest.
+                                    get_enum_string_values)),
+            Column('e8', mysql.ENUM(EnumTest.SomeEnum))
         )
 
         eq_(
@@ -707,11 +705,11 @@ class EnumSetTest(
             "e6 ENUM('''a''','b')")
         eq_(
             colspec(enum_table.c.e7),
-            "e7 ENUM('a','b')"
+            "e7 ENUM('1','2','3','a','b')"
         )
         eq_(
             colspec(enum_table.c.e8),
-            "e8 ENUM('AMember','BMember')"
+            "e8 ENUM('one','two','three','AMember','BMember')"
         )
         enum_table.create()
 
@@ -740,11 +738,11 @@ class EnumSetTest(
         expected = [(None, 'a', 'a', None, 'a', None, None, None,
                      None, None),
                     ('a', 'a', 'a', 'a', 'a', 'a', 'a', "'a'",
-                     EnumSetTest.StringEnum.AMember,
-                     EnumSetTest.StringEnum.AMember),
+                     EnumTest.SomeEnum.AMember,
+                     EnumTest.SomeEnum.AMember),
                     ('b', 'b', 'b', 'b', 'b', 'b', 'b', 'b',
-                     EnumSetTest.StringEnum.BMember,
-                     EnumSetTest.StringEnum.BMember)]
+                     EnumTest.SomeEnum.BMember,
+                     EnumTest.SomeEnum.BMember)]
 
         eq_(res, expected)
 

--- a/test/dialect/mysql/test_types.py
+++ b/test/dialect/mysql/test_types.py
@@ -13,6 +13,7 @@ from sqlalchemy import testing
 import datetime
 import decimal
 from sqlalchemy import types as sqltypes
+from enum import Enum as PyEnum
 
 
 class TypesTest(fixtures.TestBase,
@@ -651,6 +652,10 @@ class EnumSetTest(
     __dialect__ = mysql.dialect()
     __backend__ = True
 
+    class StringEnum(PyEnum):
+        AMember = 'a'
+        BMember = 'b'
+
     @testing.provide_metadata
     def test_enum(self):
         """Exercise the ENUM type."""
@@ -672,6 +677,8 @@ class EnumSetTest(
             Column('e5', mysql.ENUM("a", "b")),
             Column('e5generic', Enum("a", "b")),
             Column('e6', mysql.ENUM("'a'", "b")),
+            Column('e7', mysql.ENUM(EnumSetTest.StringEnum, values_callable=lambda x: [e.value for e in x])),
+            Column('e8', mysql.ENUM(EnumSetTest.StringEnum))
         )
 
         eq_(
@@ -698,6 +705,14 @@ class EnumSetTest(
         eq_(
             colspec(enum_table.c.e6),
             "e6 ENUM('''a''','b')")
+        eq_(
+            colspec(enum_table.c.e7),
+            "e7 ENUM('a','b')"
+        )
+        eq_(
+            colspec(enum_table.c.e8),
+            "e8 ENUM('AMember','BMember')"
+        )
         enum_table.create()
 
         assert_raises(
@@ -709,19 +724,27 @@ class EnumSetTest(
             exc.StatementError,
             enum_table.insert().execute,
             e1='c', e2='c', e2generic='c', e3='c',
-            e4='c', e5='c', e5generic='c', e6='c')
+            e4='c', e5='c', e5generic='c', e6='c',
+            e7='c', e8='c')
 
         enum_table.insert().execute()
         enum_table.insert().execute(e1='a', e2='a', e2generic='a', e3='a',
-                                    e4='a', e5='a', e5generic='a', e6="'a'")
+                                    e4='a', e5='a', e5generic='a', e6="'a'",
+                                    e7='a', e8='AMember')
         enum_table.insert().execute(e1='b', e2='b', e2generic='b', e3='b',
-                                    e4='b', e5='b', e5generic='b', e6='b')
+                                    e4='b', e5='b', e5generic='b', e6='b',
+                                    e7='b', e8='BMember')
 
         res = enum_table.select().execute().fetchall()
 
-        expected = [(None, 'a', 'a', None, 'a', None, None, None),
-                    ('a', 'a', 'a', 'a', 'a', 'a', 'a', "'a'"),
-                    ('b', 'b', 'b', 'b', 'b', 'b', 'b', 'b')]
+        expected = [(None, 'a', 'a', None, 'a', None, None, None,
+                     None, None),
+                    ('a', 'a', 'a', 'a', 'a', 'a', 'a', "'a'",
+                     EnumSetTest.StringEnum.AMember,
+                     EnumSetTest.StringEnum.AMember),
+                    ('b', 'b', 'b', 'b', 'b', 'b', 'b', 'b',
+                     EnumSetTest.StringEnum.BMember,
+                     EnumSetTest.StringEnum.BMember)]
 
         eq_(res, expected)
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,6 @@ deps=pytest
      postgresql: psycopg2>=2.7
      mysql: mysqlclient
      mysql: pymysql
-     py27-mysql: enum34
      # waiting for https://github.com/oracle/python-cx_Oracle/issues/75
      oracle: cx_oracle>=6.0.2
      oracle5: cx_oracle==5.2.1

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ deps=pytest
      postgresql: psycopg2>=2.7
      mysql: mysqlclient
      mysql: pymysql
+     py27-mysql: enum34
      # waiting for https://github.com/oracle/python-cx_Oracle/issues/75
      oracle: cx_oracle>=6.0.2
      oracle5: cx_oracle==5.2.1


### PR DESCRIPTION
This intends to resolve https://bitbucket.org/zzzeek/sqlalchemy/issues/3906

The idea is to use `values_callable` as a new kwarg to Enum.  It returns the values to be used, allowing for a variety of uses, including the one mentioned in the above issue.

Tests have been added as well as updates to the documentation.  This is my first PR to sqlalchemy so apologies in advance for things that are out of place. Particularly I wonder if this needs to be supported in postgres as the work and tests I did were for mysql.