### PR TITLE
added missing , (comma) in dialects/oracle/__init__

### DIFF
--- a/lib/sqlalchemy/dialects/oracle/__init__.py
+++ b/lib/sqlalchemy/dialects/oracle/__init__.py
@@ -19,7 +19,7 @@ from sqlalchemy.dialects.oracle.base import \
 __all__ = (
     'VARCHAR', 'NVARCHAR', 'CHAR', 'DATE', 'NUMBER',
     'BLOB', 'BFILE', 'CLOB', 'NCLOB', 'TIMESTAMP', 'RAW',
-    'FLOAT', 'DOUBLE_PRECISION', 'BINARY_DOUBLE' 'BINARY_FLOAT',
+    'FLOAT', 'DOUBLE_PRECISION', 'BINARY_DOUBLE', 'BINARY_FLOAT',
     'LONG', 'dialect', 'INTERVAL',
     'VARCHAR2', 'NVARCHAR2', 'ROWID'
 )


### PR DESCRIPTION
this resolves the following exception:

```python
>>> from sqlalchemy.dialects.oracle import *
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'sqlalchemy.dialects.oracle' has no attribute 'BINARY_DOUBLEBINARY_FLOAT'
module 'sqlalchemy.dialects.oracle' has no attribute 'BINARY_DOUBLEBINARY_FLOAT'
```