### PR TITLE
`ValuesBase.values` inconsistency fix

### DIFF
--- a/lib/sqlalchemy/sql/crud.py
+++ b/lib/sqlalchemy/sql/crud.py
@@ -600,23 +600,28 @@ def _extend_values_for_multiparams(compiler, stmt, values, kw):
     values_0 = values
     values = [values]
 
-    values.extend(
-        [
-            (
-                c,
-                (_create_bind_param(
-                    compiler, c, row[c.key],
-                    name="%s_m%d" % (c.key, i + 1), **kw
-                ) if elements._is_literal(row[c.key])
-                    else compiler.process(
-                        row[c.key].self_group(), **kw))
-                if c.key in row else
-                _process_multiparam_default_bind(compiler, stmt, c, i, kw)
-            )
-            for (c, param) in values_0
-        ]
-        for i, row in enumerate(stmt.parameters[1:])
-    )
+    for i, row in enumerate(stmt.parameters[1:]):
+        extension = []
+        for (col, param) in values_0:
+            if col in row or col.key in row:
+                key = col if col in row else col.key
+
+                if elements._is_literal(row[key]):
+                    new_param = _create_bind_param(
+                        compiler, col, row[key],
+                        name="%s_m%d" % (col.key, i + 1), **kw
+                    )
+                else:
+                    new_param = compiler.process(row[key].self_group(), **kw)
+            else:
+                new_param = _process_multiparam_default_bind(
+                    compiler, stmt, col, i, kw
+                )
+
+            extension.append((col, new_param))
+
+        values.append(extension)
+
     return values
 
 

--- a/test/sql/test_insert.py
+++ b/test/sql/test_insert.py
@@ -839,6 +839,39 @@ class MultirowTest(_InsertTestBase, fixtures.TablesTest, AssertsCompiledSQL):
             checkparams=checkparams,
             dialect=dialect)
 
+    def test_named_with_column_objects(self):
+        table1 = self.tables.mytable
+
+        values = [
+            {table1.c.myid: 1, table1.c.name: 'a', table1.c.description: 'b'},
+            {table1.c.myid: 2, table1.c.name: 'c', table1.c.description: 'd'},
+            {table1.c.myid: 3, table1.c.name: 'e', table1.c.description: 'f'},
+        ]
+
+        checkparams = {
+            'myid_m0': 1,
+            'myid_m1': 2,
+            'myid_m2': 3,
+            'name_m0': 'a',
+            'name_m1': 'c',
+            'name_m2': 'e',
+            'description_m0': 'b',
+            'description_m1': 'd',
+            'description_m2': 'f',
+        }
+
+        dialect = default.DefaultDialect()
+        dialect.supports_multivalues_insert = True
+
+        self.assert_compile(
+            table1.insert().values(values),
+            'INSERT INTO mytable (myid, name, description) VALUES '
+            '(:myid_m0, :name_m0, :description_m0), '
+            '(:myid_m1, :name_m1, :description_m1), '
+            '(:myid_m2, :name_m2, :description_m2)',
+            checkparams=checkparams,
+            dialect=dialect)
+
     def test_positional(self):
         table1 = self.tables.mytable
 


### PR DESCRIPTION
Patch allows column objects to be used as keys for the
`sqlalchemy.sql.dml.ValueBase.values` function when a list
of dictionaries is passed

Also added test case for this functionality.

I brought this up on the mailing list, linked included for reference:
https://groups.google.com/forum/?hl=en#!topic/sqlalchemy/t8a6SLTYrIc

The test suite has been run against the changed code using a sqlite and
postgresql database without issue.