### PR TITLE
Normalize check constraints even more radically

### DIFF
--- a/lib/sqlalchemy/testing/suite/test_reflection.py
+++ b/lib/sqlalchemy/testing/suite/test_reflection.py
@@ -789,12 +789,15 @@ class ComponentReflectionTest(fixtures.TablesTest):
             key=operator.itemgetter('name')
         )
 
+        # trying to minimize effect of quoting, parenthesis, etc.
+        # may need to add more to this as new dialects get CHECK
+        # constraint reflection support
+        def normalize(sqltext):
+            return " ".join(re.findall(r"and|\d|=|a|or|<|>", sqltext.lower(), re.I))
+
         reflected = [
             {"name": item["name"],
-             # trying to minimize effect of quoting, parenthesis, etc.
-             # may need to add more to this as new dialects get CHECK
-             # constraint reflection support
-             "sqltext": re.sub(r"[`'\(\)]", '', item["sqltext"].lower())}
+             "sqltext": normalize(item["sqltext"])}
             for item in reflected
         ]
         eq_(


### PR DESCRIPTION
This is the only way I could get this test pass on informix, basically I strip every whitespace.
The sql text as recorded in informix is:
```
((a > 1 ) AND (a < 5 ) )
((a = 1 ) OR ((a > 2 ) AND (a <5 ) ) )
```
Yes, this is absolutely bonkers, but that is what I get :(