### PR TITLE
Fix legacy support (missing of_type variable) for _UnboundLoad.__sets…

### DIFF
--- a/lib/sqlalchemy/orm/strategy_options.py
+++ b/lib/sqlalchemy/orm/strategy_options.py
@@ -449,6 +449,7 @@ class _UnboundLoad(Load):
                 if len(key) == 2:
                     # support legacy
                     cls, propkey = key
+                    of_type = None
                 else:
                     cls, propkey, of_type = key
                 prop = getattr(cls, propkey)


### PR DESCRIPTION
…tate__ method

While retrieving SqlAlchemy objects with dogpile cache stored by previous release (1.1.3) of SqlAlchemy exception UnboundLocalError was raised:

```UnboundLocalError: local variable 'of_type' referenced before assignment```