### PR TITLE
added a 'failed_commit' hook

### DIFF
--- a/lib/sqlalchemy/orm/events.py
+++ b/lib/sqlalchemy/orm/events.py
@@ -1285,6 +1285,8 @@ class SessionEvents(event.Events):
 
             :meth:`~.SessionEvents.after_commit`
 
+            :meth:`~.SessionEvents.failed_commit`
+
             :meth:`~.SessionEvents.after_begin`
 
             :meth:`~.SessionEvents.after_transaction_create`
@@ -1321,11 +1323,33 @@ class SessionEvents(event.Events):
 
             :meth:`~.SessionEvents.before_commit`
 
+            :meth:`~.SessionEvents.failed_commit`
+
             :meth:`~.SessionEvents.after_begin`
 
             :meth:`~.SessionEvents.after_transaction_create`
 
             :meth:`~.SessionEvents.after_transaction_end`
+
+        """
+
+    def failed_commit(self, session):
+        """Execute after a commit has raised.
+
+        .. note::
+
+            The :meth:`~.SessionEvents.failed_commit` hook is executed if an
+            exception is raised during the commit process, including
+            :meth:`~.SessionEvents.before_commit` and
+            :meth:`~.SessionEvents.after_commit` event hooks.
+
+            After this hook executes, the exception will continue to be raised.
+
+        .. seealso::
+
+            :meth:`~.SessionEvents.before_commit`
+
+            :meth:`~.SessionEvents.after_commit`
 
         """
 


### PR DESCRIPTION
This provides a method of undoing changes made in a `before_commit` hook.

Here's why I've added it:

We are indexing s3 objects in our database. In `before_commit`, we upload an object to s3. If a commit fails, we end up with garbage in s3. `failed_commit` will allow us to clean up after ourselves.

I believe SQLAlchemy is the ideal place for this (vs catching an exception on `commit` or modifying Zope etc.) as it allows us to only run `failed_commit` hooks if `before_commit` hooks successfully executed.