### PR TITLE
fix handling of native enum aliases in sqlalchemy enum columns

### DIFF
--- a/lib/sqlalchemy/sql/sqltypes.py
+++ b/lib/sqlalchemy/sql/sqltypes.py
@@ -1352,14 +1352,17 @@ class Enum(Emulated, String, SchemaType):
         self.enums = list(values)
 
         self._valid_lookup = dict(
-            zip(objects, values)
+            zip(reversed(objects), reversed(values))
         )
+
         self._object_lookup = dict(
-            (value, key) for key, value in self._valid_lookup.items()
+            zip(values, objects)
         )
-        self._valid_lookup.update(
-            [(value, value) for value in self._valid_lookup.values()]
-        )
+
+        self._valid_lookup.update([
+            (value, self._valid_lookup[self._object_lookup[value]])
+            for value in values
+        ])
 
     @property
     def native(self):


### PR DESCRIPTION
This includes the fixes [4180](https://bitbucket.org/zzzeek/sqlalchemy/issues/4180/enum-type-stores-wrong-values-in-db-when) and adds tests for [enum aliases](https://docs.python.org/3/library/enum.html#duplicating-enum-members-and-values)