### PR TITLE
Session and Query call super().__init__()

### DIFF
--- a/lib/sqlalchemy/orm/query.py
+++ b/lib/sqlalchemy/orm/query.py
@@ -110,7 +110,7 @@ class Query(object):
     _current_path = _path_registry
     _has_mapper_entities = False
 
-    def __init__(self, entities, session=None):
+    def __init__(self, entities, session=None, *args, **kwargs):
         """Construct a :class:`.Query` directly.
 
         E.g.::
@@ -138,6 +138,8 @@ class Query(object):
         self.session = session
         self._polymorphic_adapters = {}
         self._set_entities(entities)
+
+        super(Query, self).__init__(*args, **kwargs)
 
     def _set_entities(self, entities, entity_wrapper=None):
         if entity_wrapper is None:

--- a/lib/sqlalchemy/orm/session.py
+++ b/lib/sqlalchemy/orm/session.py
@@ -597,7 +597,8 @@ class Session(_SessionClassMethods):
                  weak_identity_map=True, binds=None, extension=None,
                  enable_baked_queries=True,
                  info=None,
-                 query_cls=query.Query):
+                 query_cls=query.Query,
+                 *args, **kwargs):
         r"""Construct a new Session.
 
         See also the :class:`.sessionmaker` function which is used to
@@ -776,6 +777,8 @@ class Session(_SessionClassMethods):
         if not self.autocommit:
             self.begin()
         _sessions[self.hash_key] = self
+
+        super(Session, self).__init__(*args, **kwargs)
 
     connection_callable = None
 


### PR DESCRIPTION
Simplifies life for mixins, as their __init__ execution no longer depends on coming before Session or Query in the inheritance list.