### PR TITLE
Add Query.enable_single_entity()

### DIFF
--- a/lib/sqlalchemy/orm/loading.py
+++ b/lib/sqlalchemy/orm/loading.py
@@ -37,7 +37,8 @@ def instances(query, cursor, context):
 
     filtered = query._has_mapper_entities
 
-    single_entity = len(query._entities) == 1 and \
+    single_entity = query._enable_single_entity and \
+        len(query._entities) == 1 and \
         query._entities[0].supports_single_entity
 
     if filtered:

--- a/lib/sqlalchemy/orm/loading.py
+++ b/lib/sqlalchemy/orm/loading.py
@@ -37,7 +37,7 @@ def instances(query, cursor, context):
 
     filtered = query._has_mapper_entities
 
-    single_entity = query._enable_single_entity and \
+    single_entity = not query._only_return_tuples and \
         len(query._entities) == 1 and \
         query._entities[0].supports_single_entity
 

--- a/lib/sqlalchemy/orm/query.py
+++ b/lib/sqlalchemy/orm/query.py
@@ -609,8 +609,8 @@ class Query(object):
         """When set to True, a query defined with a single entity will return a
         single entity result. This is the default.
 
-        When set to False, the query results will be a KeyedTuple of one
-        element.
+        When set to False, the query results will always be a KeyedTuple, even
+        for single element queries.
 
         """
         self._enable_single_entity = value

--- a/lib/sqlalchemy/orm/query.py
+++ b/lib/sqlalchemy/orm/query.py
@@ -606,8 +606,8 @@ class Query(object):
 
     @_generative()
     def only_return_tuples(self, value):
-        """When set to True, the query results will always be a KeyedTuple, even
-        for single element queries. The default is False.
+        """When set to True, the query results will always be a tuple,
+        specifically for single element queries. The default is False.
 
         """
         self._only_return_tuples = value

--- a/lib/sqlalchemy/orm/query.py
+++ b/lib/sqlalchemy/orm/query.py
@@ -70,7 +70,7 @@ class Query(object):
 
     """
 
-    _enable_single_entity = True
+    _only_return_tuples = False
     _enable_eagerloads = True
     _enable_assertions = True
     _with_labels = False
@@ -605,15 +605,12 @@ class Query(object):
         return self.enable_eagerloads(False).with_labels().statement
 
     @_generative()
-    def enable_single_entity(self, value):
-        """When set to True, a query defined with a single entity will return a
-        single entity result. This is the default.
-
-        When set to False, the query results will always be a KeyedTuple, even
-        for single element queries.
+    def only_return_tuples(self, value):
+        """When set to True, the query results will always be a KeyedTuple, even
+        for single element queries. The default is False.
 
         """
-        self._enable_single_entity = value
+        self._only_return_tuples = value
 
     @_generative()
     def enable_eagerloads(self, value):

--- a/lib/sqlalchemy/orm/query.py
+++ b/lib/sqlalchemy/orm/query.py
@@ -70,6 +70,7 @@ class Query(object):
 
     """
 
+    _enable_single_entity = True
     _enable_eagerloads = True
     _enable_assertions = True
     _with_labels = False
@@ -602,6 +603,17 @@ class Query(object):
 
     def __clause_element__(self):
         return self.enable_eagerloads(False).with_labels().statement
+
+    @_generative()
+    def enable_single_entity(self, value):
+        """When set to True, a query defined with a single entity will return a
+        single entity result. This is the default.
+
+        When set to False, the query results will be a KeyedTuple of one
+        element.
+
+        """
+        self._enable_single_entity = value
 
     @_generative()
     def enable_eagerloads(self, value):

--- a/test/orm/test_query.py
+++ b/test/orm/test_query.py
@@ -47,6 +47,28 @@ class MiscTest(QueryTest):
         assert q1.session is s1
 
 
+class OnlyReturnTuplesTest(QueryTest):
+    def test_single_entity_false(self):
+        User = self.classes.User
+        row = create_session().query(User).first()
+        assert isinstance(row, User)
+
+    def test_single_entity_true(self):
+        User = self.classes.User
+        row = create_session().query(User).only_return_tuples(True).first()
+        assert isinstance(row, tuple)
+
+    def test_multiple_false(self):
+        User = self.classes.User
+        row = create_session().query(User.id, User).first()
+        assert isinstance(row, tuple)
+
+    def test_multiple_true(self):
+        User = self.classes.User
+        row = create_session().query(User.id, User).only_return_tuples(True).first()
+        assert isinstance(row, tuple)
+
+
 class RowTupleTest(QueryTest):
     run_setup_mappers = None
 

--- a/test/orm/test_query.py
+++ b/test/orm/test_query.py
@@ -50,7 +50,7 @@ class MiscTest(QueryTest):
 class OnlyReturnTuplesTest(QueryTest):
     def test_single_entity_false(self):
         User = self.classes.User
-        row = create_session().query(User).first()
+        row = create_session().query(User).only_return_tuples(False).first()
         assert isinstance(row, User)
 
     def test_single_entity_true(self):
@@ -58,12 +58,12 @@ class OnlyReturnTuplesTest(QueryTest):
         row = create_session().query(User).only_return_tuples(True).first()
         assert isinstance(row, tuple)
 
-    def test_multiple_false(self):
+    def test_multiple_entity_false(self):
         User = self.classes.User
-        row = create_session().query(User.id, User).first()
+        row = create_session().query(User.id, User).only_return_tuples(False).first()
         assert isinstance(row, tuple)
 
-    def test_multiple_true(self):
+    def test_multiple_entity_true(self):
         User = self.classes.User
         row = create_session().query(User.id, User).only_return_tuples(True).first()
         assert isinstance(row, tuple)


### PR DESCRIPTION
This is useful when generating queries dynamically to avoid needing to handle two possible cases of query result structures by forcing them all to KeyedTuple.