### PR TITLE
Cloned aliased cte has it's _cte_alias trampled

### DIFF
--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -1390,8 +1390,8 @@ class CTE(Generative, HasSuffixes, Alias):
 
     def _copy_internals(self, clone=_clone, **kw):
         super(CTE, self)._copy_internals(clone, **kw)
-        if self._cte_alias is not None:
-            self._cte_alias = self
+        # if self._cte_alias is not None:
+        #     self._cte_alias = self
         self._restates = frozenset([
             clone(elem, **kw) for elem in self._restates
         ])


### PR DESCRIPTION
I couldn't figure out why CTE._copy_internals() should trample self._cte_alias. I implemented a test that demonstrates the issue if you undo the "fix" in sql/selectable.py. The commented out _cte_alias mutation fixes things for our use case, but I'm not confident I understand what is going on well enough to assert that it's a properly general fix. Perhaps I should have just opened an issue, but I had to develop a test just to get a grasp of what was going on, so here it is.