### PR TITLE
Not needed if on 217 line.

### DIFF
--- a/lib/sqlalchemy/cextension/utils.c
+++ b/lib/sqlalchemy/cextension/utils.c
@@ -214,8 +214,6 @@ initcutils(void)
 #endif
 
 #if PY_MAJOR_VERSION >= 3
-    if (m == NULL)
-        return NULL;
     return m;
 #else
     if (m == NULL)


### PR DESCRIPTION
Delite `if(m==NULL) return NULL;` becouse if m==NULL thus function return NULL