### PR TITLE
Add support for declarative partitioning in PostgreSQL 10

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -780,6 +780,11 @@ dialect in conjunction with the :class:`.Table` construct:
 
     Table("some_table", metadata, ..., postgresql_inherits=("t1", "t2", ...))
 
+* ``PARTITION BY``::
+
+    Table("some_table", metadata, ...,
+          postgresql_partition_by='LIST (part_column)')
+
 .. versionadded:: 1.0.0
 
 .. seealso::
@@ -1829,6 +1834,9 @@ class PGDDLCompiler(compiler.DDLCompiler):
                 ', '.join(self.preparer.quote(name) for name in inherits) +
                 ' )')
 
+        if pg_opts['partition_by']:
+            table_opts.append('\n PARTITION BY %s' % pg_opts['partition_by'])
+
         if pg_opts['with_oids'] is True:
             table_opts.append('\n WITH OIDS')
         elif pg_opts['with_oids'] is False:
@@ -2166,6 +2174,7 @@ class PGDialect(default.DefaultDialect):
         (schema.Table, {
             "ignore_search_path": False,
             "tablespace": None,
+            "partition_by": None,
             "with_oids": None,
             "on_commit": None,
             "inherits": None

--- a/test/dialect/postgresql/test_compiler.py
+++ b/test/dialect/postgresql/test_compiler.py
@@ -233,6 +233,26 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             'CREATE TABLE atable (id INTEGER) INHERITS '
             '( "Quote Me", "quote Me Too" )')
 
+    def test_create_table_partition_by_list(self):
+        m = MetaData()
+        tbl = Table(
+            'atable', m, Column("id", Integer), Column("part_column", Integer),
+            postgresql_partition_by='LIST (part_column)')
+        self.assert_compile(
+            schema.CreateTable(tbl),
+            'CREATE TABLE atable (id INTEGER, part_column INTEGER) '
+            'PARTITION BY LIST (part_column)')
+
+    def test_create_table_partition_by_range(self):
+        m = MetaData()
+        tbl = Table(
+            'atable', m, Column("id", Integer), Column("part_column", Integer),
+            postgresql_partition_by='RANGE (part_column)')
+        self.assert_compile(
+            schema.CreateTable(tbl),
+            'CREATE TABLE atable (id INTEGER, part_column INTEGER) '
+            'PARTITION BY RANGE (part_column)')
+
     def test_create_table_with_oids(self):
         m = MetaData()
         tbl = Table(


### PR DESCRIPTION
This adds `postgresql_partition_by` option to Table, which will insert `PARTITION BY` with user-specified partition parameters in the right place, after `INHERIT` and before `WITH/WITHOUT OIDS`. 

I was looking at Postgres docs https://www.postgresql.org/docs/current/static/sql-createtable.html

This pull request brings no particular support for creating partitions. In my project we just create them by hand when needed:

```
for table in partitioned_tables:
    stmt = f'''CREATE TABLE {table}_{partition_id}
               PARTITION OF {table} FOR VALUES in ({partition_id})'''
    db.session.execute(stmt)
```