### PR TITLE
Add support of empty list in exanding of bindparam

### DIFF
--- a/lib/sqlalchemy/engine/default.py
+++ b/lib/sqlalchemy/engine/default.py
@@ -735,14 +735,8 @@ class DefaultExecutionContext(interfaces.ExecutionContext):
             if parameter.expanding:
                 values = compiled_params.pop(name)
                 if not values:
-                    to_update = [
-                        ("%s_%s" % (name, 1), EMPTY_SET_QUERY)
-                    ]
-                    replacement_expressions[name] = ", ".join(
-                        self.compiled.bindtemplate % {
-                            "name": key}
-                        for key, value in to_update
-                    )
+                    to_update = []
+                    replacement_expressions[name] = EMPTY_SET_QUERY
 
                 elif isinstance(values[0], (tuple, list)):
                     to_update = [

--- a/lib/sqlalchemy/engine/default.py
+++ b/lib/sqlalchemy/engine/default.py
@@ -733,12 +733,10 @@ class DefaultExecutionContext(interfaces.ExecutionContext):
                 values = compiled_params.pop(name)
                 if not values:
                     to_update = []
-                    replacement_expressions[name] = str(
-                        select([1]).select_from(
-                            select([1]).alias('placeholer').where(
-                                text("1!=1")
-                            )
-                    ))
+                    replacement_expressions[name] = (
+                        self.dialect.statement_compiler(self.dialect, None)
+                            .visit_empty_set_expr()
+                    )
                 
                 elif isinstance(values[0], (tuple, list)):
                     to_update = [

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -1058,8 +1058,11 @@ class SQLCompiler(Compiled):
                 self._emit_empty_in_warning()
             return self.process(binary.left == binary.left)
 
+    def visit_empty_set_expr(self):
+        return 'SELECT 1 FROM (SELECT 1) as placeholder_table WHERE 1!=1'
+    
     def visit_binary(self, binary, override_operator=None,
-                     eager_grouping=False, **kw):
+             eager_grouping=False, **kw):
 
         # don't allow "? = ?" to render
         if self.ansi_bind_rules and \

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -1062,7 +1062,7 @@ class SQLCompiler(Compiled):
         return 'SELECT 1 FROM (SELECT 1) as placeholder_table WHERE 1!=1'
     
     def visit_binary(self, binary, override_operator=None,
-             eager_grouping=False, **kw):
+                     eager_grouping=False, **kw):
 
         # don't allow "? = ?" to render
         if self.ansi_bind_rules and \

--- a/lib/sqlalchemy/testing/suite/test_select.py
+++ b/lib/sqlalchemy/testing/suite/test_select.py
@@ -407,6 +407,30 @@ class ExpandingBoundInTest(fixtures.TablesTest):
             [(2, ), (3, ), (4, )],
             params={"q": [(2, 3), (3, 4), (4, 5)]},
         )
+        
+    def test_empty_set(self):
+        table = self.tables.some_table
+    
+        stmt = select([table.c.id]).where(
+            table.c.x.in_(bindparam('q', expanding=True))).order_by(table.c.id)
+    
+        self._assert_result(
+            stmt,
+            [],
+            params={"q": []},
+        )
+
+    def test_empty_set_negation(self):
+        table = self.tables.some_table
+    
+        stmt = select([table.c.id]).where(
+            table.c.x.notin_(bindparam('q', expanding=True))).order_by(table.c.id)
+    
+        self._assert_result(
+            stmt,
+            [(1, ), (2, ), (3, ), (4, )],
+            params={"q": []},
+        )
 
 
 class LikeFunctionsTest(fixtures.TablesTest):


### PR DESCRIPTION
Add the support of empty lists to expanding_in of bindparam, by replacing the list by a query that should do an empty list in reasonable DB : "SELECT 1 FROM ((SELECT 1) as placeholder_table) WHERE 1!=1;"
See https://groups.google.com/forum/#!topic/sqlalchemy/NLJCu_vqK4g for the discussion.

My tests in local passes, and if I understand it well, it means I only tested for sqlite. Should work for PG and mysql too, but I can't be sure for other dbs.

This is my first contribution, so I guess I did a lot of mistakes, sorry.