### PR TITLE
Added new dialect.paramstyle option to support PostgreSQL positional arguments

### DIFF
--- a/lib/sqlalchemy/engine/default.py
+++ b/lib/sqlalchemy/engine/default.py
@@ -200,7 +200,8 @@ class DefaultDialect(interfaces.Dialect):
             self.paramstyle = self.default_paramstyle
         if implicit_returning is not None:
             self.implicit_returning = implicit_returning
-        self.positional = self.paramstyle in ('qmark', 'format', 'numeric')
+        self.positional = self.paramstyle in ('qmark', 'format', 'numeric',
+                                              'dollar')
         self.identifier_preparer = self.preparer(self)
         self.type_compiler = self.type_compiler(self)
         if supports_right_nested_joins is not None:

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -60,6 +60,7 @@ BIND_TEMPLATES = {
     'qmark': "?",
     'format': "%%s",
     'numeric': ":[_POSITION]",
+    'dollar': "$[_POSITION]",
     'named': ":%(name)s"
 }
 
@@ -435,7 +436,7 @@ class SQLCompiler(Compiled):
         self.positional = dialect.positional
         if self.positional:
             self.positiontup = []
-            self._numeric_binds = dialect.paramstyle == "numeric"
+            self._numeric_binds = dialect.paramstyle in ("numeric", "dollar")
         self.bindtemplate = BIND_TEMPLATES[dialect.paramstyle]
 
         self.ctes = None

--- a/test/sql/test_compiler.py
+++ b/test/sql/test_compiler.py
@@ -432,6 +432,11 @@ class SelectTest(fixtures.TestBase, AssertsCompiledSQL):
         )
         self.assert_compile(
             stmt,
+            "select $1, $2, $3 from sometable",
+            dialect=default.DefaultDialect(paramstyle='dollar')
+        )
+        self.assert_compile(
+            stmt,
             "select %(foo)s, %(bar)s, %(bat)s from sometable",
             dialect=default.DefaultDialect(paramstyle='pyformat')
         )


### PR DESCRIPTION
This is specifically needed to properly integrate `SQLAlchemy` with `asyncpg` library. This library uses positional arguments and PostgreSQL requires `$1`-like syntax to accept such positional params.

Maybe you (@zzzeek) know how to make this possible in a simpler way? Current state looks terrible: [asyncpgsa/connection.py](https://github.com/CanopyTax/asyncpgsa/blob/f2774417d89416171b5c917f7b276d34db82c11b/asyncpgsa/connection.py#L26) - people are using weird regexp/replace stuff just to change paramstyle :(

[Here](https://github.com/CanopyTax/asyncpgsa/pull/76) I tried to make things better, but it still is not perfect. Using even one `re.sub` doesn't feels right.

And one more question. Currently it is not possible to compile final query statement with final params, which can be sent to the driver/db. Libraries like `aiopg` and `asyncpgsa` have to partially copy  `DefaultExecutionContext._init_compiled` and other methods, accessing non-public `_bind_processors` property and so on. So is it possible to made such low-level usage possible and public to help integrate SQAlchemy with other libraries? You can see how this looks right now: [aiopg/sa/connection.py](https://github.com/aio-libs/aiopg/blob/9996089f771f44006d9d4f61b3c2860944a7bd2f/aiopg/sa/connection.py#L63) :(