### PR TITLE
Sqlite json

### DIFF
--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -478,7 +478,7 @@ from ...sql import compiler
 from ...types import (BLOB, BOOLEAN, CHAR, DECIMAL, FLOAT,
                       INTEGER, REAL, NUMERIC, SMALLINT, TEXT,
                       TIMESTAMP, VARCHAR)
-from .json import JSON
+from .json import JSON, JSONIndexType, JSONPathType
 
 
 class _DateTimeMixin(object):
@@ -755,6 +755,8 @@ colspecs = {
     sqltypes.Date: DATE,
     sqltypes.DateTime: DATETIME,
     sqltypes.JSON: JSON,
+    sqltypes.JSON.JSONIndexType: JSONIndexType,
+    sqltypes.JSON.JSONPathType: JSONPathType,
     sqltypes.Time: TIME,
 }
 
@@ -857,6 +859,16 @@ class SQLiteCompiler(compiler.SQLCompiler):
     def visit_isnot_distinct_from_binary(self, binary, operator, **kw):
         return "%s IS %s" % (self.process(binary.left),
                              self.process(binary.right))
+
+    def visit_json_getitem_op_binary(self, binary, operator, **kw):
+        return "JSON_EXTRACT(%s, %s)" % (
+            self.process(binary.left, **kw),
+            self.process(binary.right, **kw))
+
+    def visit_json_path_getitem_op_binary(self, binary, operator, **kw):
+        return "JSON_EXTRACT(%s, %s)" % (
+            self.process(binary.left, **kw),
+            self.process(binary.right, **kw))
 
 
 class SQLiteDDLCompiler(compiler.DDLCompiler):

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -861,12 +861,12 @@ class SQLiteCompiler(compiler.SQLCompiler):
                              self.process(binary.right))
 
     def visit_json_getitem_op_binary(self, binary, operator, **kw):
-        return "JSON_EXTRACT(%s, %s)" % (
+        return "JSON_QUOTE(JSON_EXTRACT(%s, %s))" % (
             self.process(binary.left, **kw),
             self.process(binary.right, **kw))
 
     def visit_json_path_getitem_op_binary(self, binary, operator, **kw):
-        return "JSON_EXTRACT(%s, %s)" % (
+        return "JSON_QUOTE(JSON_EXTRACT(%s, %s))" % (
             self.process(binary.left, **kw),
             self.process(binary.right, **kw))
 

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -478,6 +478,7 @@ from ...sql import compiler
 from ...types import (BLOB, BOOLEAN, CHAR, DECIMAL, FLOAT,
                       INTEGER, REAL, NUMERIC, SMALLINT, TEXT,
                       TIMESTAMP, VARCHAR)
+from .json import JSON
 
 
 class _DateTimeMixin(object):
@@ -753,6 +754,7 @@ class TIME(_DateTimeMixin, sqltypes.Time):
 colspecs = {
     sqltypes.Date: DATE,
     sqltypes.DateTime: DATETIME,
+    sqltypes.JSON: JSON,
     sqltypes.Time: TIME,
 }
 
@@ -771,6 +773,7 @@ ischema_names = {
     'FLOAT': sqltypes.FLOAT,
     'INT': sqltypes.INTEGER,
     'INTEGER': sqltypes.INTEGER,
+    'JSON': JSON,
     'NUMERIC': sqltypes.NUMERIC,
     'REAL': sqltypes.REAL,
     'SMALLINT': sqltypes.SMALLINT,
@@ -973,6 +976,9 @@ class SQLiteTypeCompiler(compiler.GenericTypeCompiler):
         else:
             return "TIME_CHAR"
 
+    def visit_JSON(self, type_, **kw):
+        return "JSON"
+
 
 class SQLiteIdentifierPreparer(compiler.IdentifierPreparer):
     reserved_words = set([
@@ -1065,9 +1071,12 @@ class SQLiteDialect(default.DefaultDialect):
     _broken_fk_pragma_quotes = False
     _broken_dotted_colnames = False
 
-    def __init__(self, isolation_level=None, native_datetime=False, **kwargs):
+    def __init__(self, isolation_level=None, native_datetime=False,
+                 _json_serializer=None, _json_deserializer=None, **kwargs):
         default.DefaultDialect.__init__(self, **kwargs)
         self.isolation_level = isolation_level
+        self._json_serializer = _json_serializer
+        self._json_deserializer = _json_deserializer
 
         # this flag used by pysqlite dialect, and perhaps others in the
         # future, to indicate the driver is handling date/timestamp

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -989,6 +989,12 @@ class SQLiteTypeCompiler(compiler.GenericTypeCompiler):
             return "TIME_CHAR"
 
     def visit_JSON(self, type_, **kw):
+        # TODO: JSON has NUMERIC affinity, not TEXT.
+        # If a user stores a JSON numeric value, it will be stored using
+        # NUMERIC storage class, which will blow up deserialization.
+        # As an alternative this could be for example JSONTEXT or some
+        # such, which would allow reflection to recognize JSON columns,
+        # and would ensure TEXT affinity.
         return "JSON"
 
 

--- a/lib/sqlalchemy/dialects/sqlite/json.py
+++ b/lib/sqlalchemy/dialects/sqlite/json.py
@@ -12,23 +12,6 @@ class JSON(sqltypes.JSON):
     .. _`loadable extension`: https://www.sqlite.org/loadext.html
     """
 
-    class Comparator(sqltypes.JSON.Comparator):
-        """Define comparison operations for :class:`.JSON`."""
-
-        def _setup_getitem(self, index):
-            operator, index, _ = super()._setup_getitem(index)
-            # https://www.sqlite.org/json1.html#jex
-            # "the SQL datatype of the result is NULL for a JSON null, INTEGER
-            # or REAL for a JSON numeric value, an INTEGER zero for a JSON false
-            # value, an INTEGER one for a JSON true value, the dequoted text for
-            # a JSON string value, and a text representation for JSON object and
-            # array values. If there are multiple path arguments (P1, P2, and so
-            # forth) then this routine returns SQLite text which is a
-            # well-formed JSON array holding the various values."
-            return operator, index, sqltypes.NullType()
-
-    comparator_factory = Comparator
-
 
 # TODO: MySQL and SQLite seem to share the same JSON path syntax, maybe unify?
 class _FormatTypeMixin(object):

--- a/lib/sqlalchemy/dialects/sqlite/json.py
+++ b/lib/sqlalchemy/dialects/sqlite/json.py
@@ -4,12 +4,19 @@ from ... import types as sqltypes
 class JSON(sqltypes.JSON):
     """SQLite JSON type.
 
-    SQLite supports JSON as of version 3.9 through its JSON1_ extension.
-    Note that JSON1_ is a `loadable extension`_ and as such may not be
-    available, or may require run-time loading.
+    SQLite supports JSON as of version 3.9 through its JSON1_ extension. Note
+    that JSON1_ is a `loadable extension <https://www.sqlite.org/loadext.html>`_
+    and as such may not be available, or may require run-time loading.
 
+    The :class:`.sqlite.JSON` type supports persistence of JSON values
+    as well as the core index operations provided by :class:`.types.JSON`
+    datatype, by adapting the operations to render the ``JSON_EXTRACT``
+    function wrapped in the ``JSON_QUOTE`` function at the database level.
+    Extracted values are quoted in order to ensure that the results are
+    always JSON string values.
+
+    .. versionadded:: N/A
     .. _JSON1: https://www.sqlite.org/json1.html
-    .. _`loadable extension`: https://www.sqlite.org/loadext.html
     """
 
 

--- a/lib/sqlalchemy/dialects/sqlite/json.py
+++ b/lib/sqlalchemy/dialects/sqlite/json.py
@@ -1,0 +1,30 @@
+from ... import types as sqltypes
+
+
+class JSON(sqltypes.JSON):
+    """SQLite JSON type.
+
+    SQLite supports JSON as of version 3.9 through its JSON1_ extension.
+    Note that JSON1_ is a `loadable extension`_ and as such may not be
+    available, or may require run-time loading.
+
+    .. _JSON1: https://www.sqlite.org/json1.html
+    .. _`loadable extension`: https://www.sqlite.org/loadext.html
+    """
+
+    class Comparator(sqltypes.JSON.Comparator):
+        """Define comparison operations for :class:`.JSON`."""
+
+        def _setup_getitem(self, index):
+            operator, index, _ = super()._setup_getitem(index)
+            # https://www.sqlite.org/json1.html#jex
+            # "the SQL datatype of the result is NULL for a JSON null, INTEGER
+            # or REAL for a JSON numeric value, an INTEGER zero for a JSON false
+            # value, an INTEGER one for a JSON true value, the dequoted text for
+            # a JSON string value, and a text representation for JSON object and
+            # array values. If there are multiple path arguments (P1, P2, and so
+            # forth) then this routine returns SQLite text which is a
+            # well-formed JSON array holding the various values."
+            return operator, index, sqltypes.NullType()
+
+    comparator_factory = Comparator

--- a/lib/sqlalchemy/dialects/sqlite/json.py
+++ b/lib/sqlalchemy/dialects/sqlite/json.py
@@ -28,3 +28,51 @@ class JSON(sqltypes.JSON):
             return operator, index, sqltypes.NullType()
 
     comparator_factory = Comparator
+
+
+# TODO: MySQL and SQLite seem to share the same JSON path syntax, maybe unify?
+class _FormatTypeMixin(object):
+    def _format_value(self, value):
+        raise NotImplementedError()
+
+    def bind_processor(self, dialect):
+        super_proc = self.string_bind_processor(dialect)
+
+        def process(value):
+            value = self._format_value(value)
+            if super_proc:
+                value = super_proc(value)
+            return value
+
+        return process
+
+    def literal_processor(self, dialect):
+        super_proc = self.string_literal_processor(dialect)
+
+        def process(value):
+            value = self._format_value(value)
+            if super_proc:
+                value = super_proc(value)
+            return value
+
+        return process
+
+
+class JSONIndexType(_FormatTypeMixin, sqltypes.JSON.JSONIndexType):
+
+    def _format_value(self, value):
+        if isinstance(value, int):
+            value = "$[%s]" % value
+        else:
+            value = '$."%s"' % value
+        return value
+
+
+class JSONPathType(_FormatTypeMixin, sqltypes.JSON.JSONPathType):
+    def _format_value(self, value):
+        return "$%s" % (
+            "".join([
+                "[%s]" % elem if isinstance(elem, int)
+                else '."%s"' % elem for elem in value
+            ])
+        )

--- a/test/dialect/test_sqlite.py
+++ b/test/dialect/test_sqlite.py
@@ -219,6 +219,34 @@ class TestTypes(fixtures.TestBase, AssertsExecutionResults):
                 isinstance(bindproc(util.u('some string')), util.text_type)
 
 
+class JSONTest(fixtures.TestBase):
+
+    __requires__ = ('json_type', )
+    __only_on__ = 'sqlite'
+
+    @testing.provide_metadata
+    def test_rudimentary_roundtrip(self):
+        sqlite_json = Table(
+            'json_test', self.metadata,
+            Column('foo', sqlite.JSON)
+        )
+
+        self.metadata.create_all()
+
+        value = {
+            'json': {'foo': 'bar'},
+            'recs': ['one', 'two']
+        }
+
+        with testing.db.connect() as conn:
+            conn.execute(sqlite_json.insert(), foo=value)
+
+            eq_(
+                conn.scalar(select([sqlite_json.c.foo])),
+                value
+            )
+
+
 class DateTimeTest(fixtures.TestBase, AssertsCompiledSQL):
 
     def test_time_microseconds(self):

--- a/test/dialect/test_sqlite.py
+++ b/test/dialect/test_sqlite.py
@@ -260,7 +260,7 @@ class JSONTest(fixtures.TestBase):
             )
 
     @testing.provide_metadata
-    def test_extra_subobject(self):
+    def test_extract_subobject(self):
         sqlite_json = Table(
             'json_test', self.metadata,
             Column('foo', sqlite.JSON)

--- a/test/requirements.py
+++ b/test/requirements.py
@@ -678,7 +678,8 @@ class DefaultRequirements(SuiteRequirements):
                         (10, 2, 7)
                     )
                 ),
-            "postgresql >= 9.3"
+            "postgresql >= 9.3",
+            "sqlite >= 3.9"
         ])
 
     @property
@@ -686,7 +687,8 @@ class DefaultRequirements(SuiteRequirements):
         return only_on([
             lambda config: against(config, "mysql >= 5.7") and
             not config.db.dialect._is_mariadb,
-            "postgresql >= 9.3"
+            "postgresql >= 9.3",
+            "sqlite >= 3.9"
         ])
 
     @property


### PR DESCRIPTION
This is a skeleton implementation of JSON type for SQLite. There are some open issues, but the usual functionality is there.

Issues:

- Current implementation uses `JSON` typename, which has numeric affinity, not text. This is an issue, if a numeric JSON value is stored, as SQLite will use some numeric storage class, which will trip deserialization.