### PR TITLE
Fix lazy loading of relations from identity map for sharded setups

### DIFF
--- a/lib/sqlalchemy/orm/strategies.py
+++ b/lib/sqlalchemy/orm/strategies.py
@@ -612,7 +612,10 @@ class LazyLoader(AbstractRelationshipLoader, util.MemoizedSlots):
             if _none_set.issuperset(ident):
                 return None
 
-            ident_key = self.mapper.identity_key_from_primary_key(ident)
+            ident_key = self.mapper.identity_key_from_primary_key(
+                ident,
+                identity_token=state.identity_token
+            )
             instance = loading.get_from_identity(session, ident_key, passive)
             if instance is not None:
                 return instance

--- a/test/ext/test_horizontal_shard.py
+++ b/test/ext/test_horizontal_shard.py
@@ -372,3 +372,47 @@ class SelectinloadRegressionTest(fixtures.DeclarativeMappedTest):
 
         result = session.query(Book).options(selectinload('pages')).all()
         eq_(result, [book])
+
+
+class LazyLoadFromIdentityMapTest(fixtures.DeclarativeMappedTest):
+    @classmethod
+    def setup_classes(cls):
+        Base = cls.DeclarativeBasic
+
+        class Book(Base):
+            __tablename__ = 'book'
+            id = Column(Integer, primary_key=True)
+            pages = relationship('Page', backref='book')
+
+        class Page(Base):
+            __tablename__ = 'page'
+            id = Column(Integer, primary_key=True)
+            book_id = Column(ForeignKey('book.id'))
+
+    def test_lazy_load_from_identity_map(self):
+        session = ShardedSession(
+            shards={"test": testing.db},
+            shard_chooser=lambda *args: 'test',
+            id_chooser=lambda *args: None,
+            query_chooser=lambda *args: ['test']
+        )
+
+        Book, Page = self.classes("Book", "Page")
+        book = Book()
+        book.pages.append(Page())
+
+        session.add(book)
+        session.commit()
+
+        book = session.query(Book).first()
+        page = session.query(Page).first()
+
+        def go():
+            eq_(page.book, book)
+
+        # doesn't emit SQL
+        self.assert_sql_count(
+            testing.db,
+            go,
+            0
+        )


### PR DESCRIPTION
After shipping 1.2 to production, we noticed a significant increase in
query throughput. After investigation, I think the loading strategy
needs to supply identity_token to identity_key_from_primary_key in order
for there to be a successful lookup against the identity map.

Is it safe to pass the state's identity token?