### PR TITLE
Oracle stores INTEGER as NULL precision with scale == 0

### DIFF
--- a/lib/sqlalchemy/dialects/oracle/base.py
+++ b/lib/sqlalchemy/dialects/oracle/base.py
@@ -596,6 +596,9 @@ class OracleTypeCompiler(compiler.GenericTypeCompiler):
             scale = getattr(type_, 'scale', None)
 
         if precision is None:
+            # Oracle stores INTEGER as NULL precision and 0 scale:
+            if scale == 0 and name == "NUMBER":
+                return "INTEGER"
             return name
         elif scale is None:
             n = "%(name)s(%(precision)s)"


### PR DESCRIPTION
SqlAlchemy should render NUMBER of NULL precision and scale == 0 as INTEGER instead of NUMBER
(Otherwise roundtrip reflection re-creation changes original datatype.)

See RoundTripNumericTypeTest for failure case.