### PR TITLE
mssql: add visitor for sequence objects

### DIFF
--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -1532,6 +1532,10 @@ class MSSQLCompiler(compiler.SQLCompiler):
                                  fromhints=from_hints, **kw)
             for t in [from_table] + extra_froms)
 
+    def visit_sequence(self, seq):
+        return 'NEXT VALUE FOR {}'.format(
+                self.preparer.format_sequence(seq))
+
 
 class MSSQLStrictCompiler(MSSQLCompiler):
 


### PR DESCRIPTION
This pull request adds a visitor for SQL Server 'Sequence' database objects. This should allow users to more easily access mssql sequence objects from sqlalchemy.