### PR TITLE
Fix reference leak in compiled cache

### DIFF
--- a/lib/sqlalchemy/engine/base.py
+++ b/lib/sqlalchemy/engine/base.py
@@ -1023,9 +1023,13 @@ class Connection(Connectable):
 
         distilled_params = _distill_params(multiparams, params)
         if distilled_params:
-            # note this is usually dict but we support RowProxy
-            # as well; but dict.keys() as an iterable is OK
-            keys = distilled_params[0].keys()
+            # note this is usually dict but we support RowProxy as well; but
+            # dict.keys() as an iterable is OK. Note that in Python 3 and
+            # later, a dict_keys instance keeps a reference to the underlying
+            # dict and therefore to the values. We explicitly copy the keys as
+            # a list to ensure that cached entries do not hold a reference to
+            # the parameter values.
+            keys = list(distilled_params[0].keys())
         else:
             keys = []
 

--- a/test/engine/test_execute.py
+++ b/test/engine/test_execute.py
@@ -1,12 +1,14 @@
 # coding: utf-8
 
+import weakref
 from sqlalchemy.testing import eq_, assert_raises, assert_raises_message, \
     config, is_, is_not_, le_, expect_warnings
 import re
 from sqlalchemy.testing.util import picklers
 from sqlalchemy.interfaces import ConnectionProxy
 from sqlalchemy import MetaData, Integer, String, INT, VARCHAR, func, \
-    bindparam, select, event, TypeDecorator, create_engine, Sequence
+    bindparam, select, event, TypeDecorator, create_engine, Sequence, \
+    LargeBinary
 from sqlalchemy.sql import column, literal
 from sqlalchemy.testing.schema import Table, Column
 import sqlalchemy as tsa
@@ -43,6 +45,7 @@ class ExecuteTest(fixtures.TestBase):
             'users', metadata,
             Column('user_id', INT, primary_key=True, autoincrement=False),
             Column('user_name', VARCHAR(20)),
+            Column('photo_blob', LargeBinary()),
         )
         users_autoinc = Table(
             'users_autoinc', metadata,
@@ -769,6 +772,33 @@ class CompiledCacheTest(fixtures.TestBase):
         eq_(compile_mock.call_count, 1)
         assert len(cache) == 1
         eq_(conn.execute("select count(*) from users").scalar(), 3)
+
+    def test_cache_noleak_on_statement_values(self):
+        # This is a non regression test for an object reference leak caused
+        # by the compiled_cache.
+        conn = testing.db.connect()
+        cache = {}
+        cached_conn = conn.execution_options(compiled_cache=cache)
+
+        class PhotoBlob(bytearray):
+            pass
+
+        blob = PhotoBlob(100)
+        ref_blob = weakref.ref(blob)
+
+        ins = users.insert()
+        with patch.object(
+            ins, "compile",
+                Mock(side_effect=ins.compile)) as compile_mock:
+            cached_conn.execute(ins, {'user_name': 'u1', 'photo_blob': blob})
+        eq_(compile_mock.call_count, 1)
+        assert len(cache) == 1
+        eq_(conn.execute("select count(*) from users").scalar(), 1)
+
+        del blob
+        # The compiled statement cache should not hold any reference to the
+        # the statement values (only the keys).
+        eq_(ref_blob(), None)
 
     def test_keys_independent_of_ordering(self):
         conn = testing.db.connect()


### PR DESCRIPTION
On Python 3, the `dict_keys` used as attribute in the compiled cache entries holds a reference to the full parameter dict, therefore preventing the timely garbage collection of large parameter values (for instance a large binary object).

Forcing a list copy of the keys (parameter names) fixes the issue.

This PR includes a non-regression test.