### PR TITLE
Fix string formatting TypeError if tuple is passed

### DIFF
--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -4283,7 +4283,7 @@ def _no_literals(element):
         raise exc.ArgumentError("Ambiguous literal: %r.  Use the 'text()' "
                                 "function to indicate a SQL expression "
                                 "literal, or 'literal()' to indicate a "
-                                "bound value." % element)
+                                "bound value." % (element,))
     else:
         return element
 


### PR DESCRIPTION
If a tuple is mistakenly passed where a condition or other element was expected, instead of the proper `ArgumentError`, the caller will get a more cryptic `TypeError` complaining about *not all arguments converted during string formatting*.