### PR TITLE
sqltypes.py: add json (de)serializers for dialects which lack corresp…

### DIFF
--- a/lib/sqlalchemy/sql/sqltypes.py
+++ b/lib/sqlalchemy/sql/sqltypes.py
@@ -2126,7 +2126,7 @@ class JSON(Indexable, TypeEngine):
     def bind_processor(self, dialect):
         string_process = self._str_impl.bind_processor(dialect)
 
-        json_serializer = dialect._json_serializer or json.dumps
+        json_serializer = getattr(dialect, '_json_serializer', None) or json.dumps
 
         def process(value):
             if value is self.NULL:
@@ -2145,7 +2145,7 @@ class JSON(Indexable, TypeEngine):
 
     def result_processor(self, dialect, coltype):
         string_process = self._str_impl.result_processor(dialect, coltype)
-        json_deserializer = dialect._json_deserializer or json.loads
+        json_deserializer = getattr(dialect, '_json_deserializer', None) or json.loads
 
         def process(value):
             if value is None:


### PR DESCRIPTION
* Summary
When implementing json type for dialects which doesn't support it, default json serializer is not defined.

* Details
All methods and classes here to keep the example minimal but complete are void to keep the example minimal and complete. Removing the `coerce_compared_value` would not trigger the bug, but this is needed thereafter for comparators to work with native python dictionnary.

Running with 'master' triggers
`(exceptions.AttributeError) 'SQLiteDialect_pysqlite' object has no attribute '_json_serializer'`


* MCVE
Tested with python 3.6 and 2.7

```
import json
import sqlalchemy

from sqlalchemy import insert, select, Column, Text, Integer, String
from sqlalchemy.ext.declarative import declarative_base
from sqlalchemy.sql.expression import literal
from sqlalchemy.types import TypeDecorator, Boolean, JSON


class DefaultJSON(TypeDecorator):
    
    impl = Text

    def load_dialect_impl(self, dialect):
        return dialect.type_descriptor(Text())

    def coerce_compared_value(self, op, value):
        return JSON().coerce_compared_value(op, value)

    class Comparator(JSON.comparator_factory):
        """Mixed comparator_factory."""
    comparator_factory = Comparator

    def process_bind_param(self, value, dialect):
        if value is None:
            return value
        value = json.dumps(value)
        return value

    def process_result_value(self, value, dialect):
        if value is None:
            return value
        value = json.loads(value)
        return value

SQLJSON = DefaultJSON
Base = declarative_base()
db = sqlalchemy.create_engine("sqlite:////tmp/db.db", echo=True)

class Users(Base):
    __tablename__ = "users"
    id = Column(Integer, primary_key=True)
    name = Column(String(32))
    infos = Column(SQLJSON)

def main():
    Users.__table__.create(bind=db)
    insrt = insert(Users)
    insrt = insrt.values({'name': 'user1', 'infos': {"1": 1, "4": 4, "tab": "stab"}})
    db.execute(insrt)
    slct = select([Users])
    slct = slct.where(Users.infos == {"1": 1, "4": 4, "tab": "stab"})
    row = db.execute(slct)
    return row
```