### PR TITLE
fixes #4260: PGDialect supports_native_decimal

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -2158,6 +2158,7 @@ class PGDialect(default.DefaultDialect):
 
     supports_native_enum = True
     supports_native_boolean = True
+    supports_native_decimal = True
     supports_smallserial = True
 
     supports_sequences = True


### PR DESCRIPTION
See https://bitbucket.org/zzzeek/sqlalchemy/issues/4260/pgdialect-should-support-native-decimal