### PR TITLE
Add the kwargs to the Adapt method

### DIFF
--- a/doc/build/core/custom_types.rst
+++ b/doc/build/core/custom_types.rst
@@ -324,7 +324,7 @@ cursor directly::
                   return None
           return process
 
-      def adapt(self, impltype):
+      def adapt(self, impltype, **kw):
           return MySpecialTime(self.special_argument)
 
 .. _types_sql_value_processing:


### PR DESCRIPTION
Hi all,

I've been working on a dialect, and I stumbled upon this. This will override the original signature of the method:
https://github.com/zzzeek/sqlalchemy/blob/master/lib/sqlalchemy/sql/type_api.py#L522

Cheers, Fokko