### PR TITLE
Fix microsecond converting to milliseconds

### DIFF
--- a/lib/sqlalchemy/cextension/processors.c
+++ b/lib/sqlalchemy/cextension/processors.c
@@ -9,6 +9,8 @@ the MIT License: http://www.opensource.org/licenses/mit-license.php
 
 #include <Python.h>
 #include <datetime.h>
+#include <string.h>
+#include <stdlib.h>
 
 #define MODULE_NAME "cprocessors"
 #define MODULE_DOC "Module containing C versions of data processing functions."
@@ -68,7 +70,9 @@ str_to_datetime(PyObject *self, PyObject *arg)
 #endif
     const char *str;
     int numparsed;
-    unsigned int year, month, day, hour, minute, second, microsecond = 0;
+    char microsecond[] = "000000";
+    char ms[] = "000000";
+    unsigned int year, month, day, hour, minute, second = 0;
     PyObject *err_repr;
 
     if (arg == Py_None)
@@ -114,8 +118,8 @@ str_to_datetime(PyObject *self, PyObject *arg)
     not accept "2000-01-01 00:00:00.". I don't know which is better, but they
     should be coherent.
     */
-    numparsed = sscanf(str, "%4u-%2u-%2u %2u:%2u:%2u.%6u", &year, &month, &day,
-                       &hour, &minute, &second, &microsecond);
+    numparsed = sscanf(str, "%4u-%2u-%2u %2u:%2u:%2u.%6s", &year, &month, &day,
+                       &hour, &minute, &second, ms);
 #if PY_MAJOR_VERSION >= 3
     Py_DECREF(bytes);
 #endif
@@ -141,8 +145,12 @@ str_to_datetime(PyObject *self, PyObject *arg)
         Py_DECREF(err_repr);
         return NULL;
     }
+
+    for(unsigned long i=0; i<strlen(ms); i++){
+        microsecond[i] = ms[i];
+    }
     return PyDateTime_FromDateAndTime(year, month, day,
-                                      hour, minute, second, microsecond);
+                                      hour, minute, second, atoi(microsecond));
 }
 
 static PyObject *
@@ -153,8 +161,10 @@ str_to_time(PyObject *self, PyObject *arg)
     PyObject *err_bytes;
 #endif
     const char *str;
+    char microsecond[] = "000000";
+    char ms[] = "000000";
     int numparsed;
-    unsigned int hour, minute, second, microsecond = 0;
+    unsigned int hour, minute, second = 0;
     PyObject *err_repr;
 
     if (arg == Py_None)
@@ -199,8 +209,8 @@ str_to_time(PyObject *self, PyObject *arg)
     not accept "00:00:00.". I don't know which is better, but they should be
     coherent.
     */
-    numparsed = sscanf(str, "%2u:%2u:%2u.%6u", &hour, &minute, &second,
-                       &microsecond);
+    numparsed = sscanf(str, "%2u:%2u:%2u.%6s", &hour, &minute, &second,
+                       ms);
 #if PY_MAJOR_VERSION >= 3
     Py_DECREF(bytes);
 #endif
@@ -226,7 +236,10 @@ str_to_time(PyObject *self, PyObject *arg)
         Py_DECREF(err_repr);
         return NULL;
     }
-    return PyTime_FromTime(hour, minute, second, microsecond);
+    for(unsigned long i=0; i<strlen(ms); i++){
+        microsecond[i] = ms[i];
+    }
+    return PyTime_FromTime(hour, minute, second, atoi(microsecond));
 }
 
 static PyObject *

--- a/lib/sqlalchemy/processors.py
+++ b/lib/sqlalchemy/processors.py
@@ -45,7 +45,10 @@ def str_to_datetime_processor_factory(regexp, type_):
                     list(map(int, iter(groups.values())))
                 ))))
             else:
-                return type_(*list(map(int, m.groups(0))))
+                groups = list(m.groups('0'))
+                if len(groups) in (4, 7):  # Time or Datetime with microseconds
+                    groups[-1] = groups[-1].ljust(6, '0')
+                return type_(*list(map(int, groups)))
     return process
 
 

--- a/test/engine/test_processors.py
+++ b/test/engine/test_processors.py
@@ -86,6 +86,22 @@ class _DateProcessorTest(fixtures.TestBase):
             self.module.str_to_time, "5:a"
         )
 
+    def test_datetime_microseconds(self):
+        dt = str(self.module.str_to_datetime('2018-01-02 03:45:30.456'))
+        eq_(dt, '2018-01-02 03:45:30.456000')
+
+    def test_datetime_microseconds2(self):
+        dt = str(self.module.str_to_datetime('2018-01-02 03:45:30.00456'))
+        eq_(dt, '2018-01-02 03:45:30.004560')
+
+    def test_time_microseconds(self):
+        dt = str(self.module.str_to_time('03:45:30.456'))
+        eq_(dt, '03:45:30.456000')
+
+    def test_time_microseconds2(self):
+        dt = str(self.module.str_to_time('03:45:30.00456'))
+        eq_(dt, '03:45:30.004560')
+
 
 class PyDateProcessorTest(_DateProcessorTest):
     @classmethod


### PR DESCRIPTION
A db may return a datetime as “2018-01-01 03:45:30.450”
This would be 450 milliseconds or 450000 microseconds. The regex just
parses out 450, but does not know that it needs to be interpreted with
zeros padded on the right up to 6 digits.
The regex and later int conversion would treat “2018-01-01
03:45:30.450” as the same as “2018-01-01 03:45:30.000450”

This fix pads the microseconds with zeros on the right up to 6 digits. Ensuring the correct value when passed to datetime.datetime. 

* Forgive my C coding. I'm sure there is a better way to implement