### PR TITLE
fix TypeReflectionTest for sqlite 3.24

### DIFF
--- a/test/dialect/test_sqlite.py
+++ b/test/dialect/test_sqlite.py
@@ -1637,7 +1637,7 @@ class TypeReflectionTest(fixtures.TestBase):
             ("BLOBBER", sqltypes.NullType()),
             ("DOUBLE PRECISION", sqltypes.REAL()),
             ("FLOATY", sqltypes.REAL()),
-            ("NOTHING WE KNOW", sqltypes.NUMERIC()),
+            ("SOMETHING UNKNOWN", sqltypes.NUMERIC()),
         ]
 
     def _fixture_as_string(self, fixture):


### PR DESCRIPTION
SQLite 3.24 added support for PostgreSQL-style UPSERT. This added two new keywords 'DO' and 'NOTHING' which made test_round_trip_direct_type_affinity() fail with a syntax error.