### PR TITLE
Mention Properties keys in __dir__

### DIFF
--- a/lib/sqlalchemy/util/_collections.py
+++ b/lib/sqlalchemy/util/_collections.py
@@ -185,7 +185,7 @@ class Properties(object):
         return iter(list(self._data.values()))
 
     def __dir__(self):
-        return super().__dir__() + [str(k) for k in self._data.keys()]
+        return super(Properties, self).__dir__() + [str(k) for k in self._data.keys()]
 
     def __add__(self, other):
         return list(self) + list(other)

--- a/lib/sqlalchemy/util/_collections.py
+++ b/lib/sqlalchemy/util/_collections.py
@@ -184,6 +184,9 @@ class Properties(object):
     def __iter__(self):
         return iter(list(self._data.values()))
 
+    def __dir__(self):
+        return super().__dir__() + [str(k) for k in self._data.keys()]
+
     def __add__(self, other):
         return list(self) + list(other)
 

--- a/test/base/test_utils.py
+++ b/test/base/test_utils.py
@@ -3,7 +3,8 @@ import sys
 
 from sqlalchemy import util, sql, exc, testing
 from sqlalchemy.testing import assert_raises, assert_raises_message, fixtures
-from sqlalchemy.testing import eq_, is_, ne_, fails_if, mock, expect_warnings
+from sqlalchemy.testing import eq_, in_, is_, ne_, fails_if, mock
+from sqlalchemy.testing import expect_warnings
 from sqlalchemy.testing.util import picklers, gc_collect
 from sqlalchemy.util import classproperty, WeakSequence, get_callable_argspec
 from sqlalchemy.sql import column
@@ -2348,7 +2349,7 @@ class TestProperties(fixtures.TestBase):
     def test_keys_in_dir(self):
         data = {'hello': 'bla'}
         props = util.Properties(data)
-        assert 'hello' in dir(props)
+        in_('hello', dir(props))
 
     def test_pickle_immuatbleprops(self):
         data = {'hello': 'bla'}

--- a/test/base/test_utils.py
+++ b/test/base/test_utils.py
@@ -2345,6 +2345,11 @@ class TestProperties(fixtures.TestBase):
             eq_(props._data, p._data)
             eq_(props.keys(), p.keys())
 
+    def test_keys_in_dir(self):
+        data = {'hello': 'bla'}
+        props = util.Properties(data)
+        assert 'hello' in dir(props)
+
     def test_pickle_immuatbleprops(self):
         data = {'hello': 'bla'}
         props = util.Properties(data).as_immutable()


### PR DESCRIPTION
This enables autocompletion in e.g. `ipython` to work on `table.c.<TAB>`.