### PR TITLE
Update URL for PyMySQL documentation

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/pymysql.py
+++ b/lib/sqlalchemy/dialects/mysql/pymysql.py
@@ -12,7 +12,7 @@
     :dbapi: pymysql
     :connectstring: mysql+pymysql://<username>:<password>@<host>/<dbname>\
 [?<options>]
-    :url: http://www.pymysql.org/
+    :url: https://pymysql.readthedocs.io/
 
 Unicode
 -------


### PR DESCRIPTION
The [current link](http://www.pymysql.org/) points to a domain parking site. I've updated the URL to the official one linked from their [GitHub project](https://github.com/PyMySQL/PyMySQL).