### PR TITLE
Use MySQL protocol-level ping.

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/mysqldb.py
+++ b/lib/sqlalchemy/dialects/mysql/mysqldb.py
@@ -101,6 +101,17 @@ class MySQLDialect_mysqldb(MySQLDialect):
     def dbapi(cls):
         return __import__('MySQLdb')
 
+    def do_ping(self, dbapi_connection):
+        try:
+            dbapi_connection.ping()
+        except self.dbapi.Error as err:
+            if self.is_disconnect(err, dbapi_connection, None):
+                return False
+            else:
+                raise
+        else:
+            return True
+
     def do_executemany(self, cursor, statement, parameters, context=None):
         rowcount = cursor.executemany(statement, parameters)
         if context is not None:


### PR DESCRIPTION
Utilizes MySQL protocol-level pings for disconnection detection.
This is just a 5-byte packet followed by a 7-byte response.

Affects MySQLdb and PyMySQL dialects.