### PR TITLE
Fix collections ABC acces before Python 3.8

### DIFF
--- a/lib/sqlalchemy/util/__init__.py
+++ b/lib/sqlalchemy/util/__init__.py
@@ -21,7 +21,7 @@ from ._collections import KeyedTuple, ImmutableContainer, immutabledict, \
     UniqueAppender, PopulateDict, EMPTY_SET, to_list, to_set, \
     to_column_set, update_copy, flatten_iterator, has_intersection, \
     LRUCache, ScopedRegistry, ThreadLocalRegistry, WeakSequence, \
-    coerce_generator_arg, lightweight_named_tuple
+    coerce_generator_arg, lightweight_named_tuple, collections_abc
 
 from .langhelpers import iterate_attributes, class_hierarchy, \
     portable_instancemethod, unbound_method_to_callable, \

--- a/lib/sqlalchemy/util/_collections.py
+++ b/lib/sqlalchemy/util/_collections.py
@@ -11,10 +11,10 @@ from __future__ import absolute_import
 import weakref
 import operator
 from .compat import threading, itertools_filterfalse, string_types, \
-    binary_types
+    binary_types, collections_abc
 from . import py2k
 import types
-import collections
+
 
 EMPTY_SET = frozenset()
 
@@ -795,7 +795,7 @@ def coerce_generator_arg(arg):
 def to_list(x, default=None):
     if x is None:
         return default
-    if not isinstance(x, collections.Iterable) or \
+    if not isinstance(x, collections_abc.Iterable) or \
             isinstance(x, string_types + binary_types):
         return [x]
     elif isinstance(x, list):

--- a/lib/sqlalchemy/util/compat.py
+++ b/lib/sqlalchemy/util/compat.py
@@ -327,3 +327,12 @@ def nested(*managers):
                 exc = sys.exc_info()
         if exc != (None, None, None):
             reraise(exc[0], exc[1], exc[2])
+
+
+# Fix deprecation of accessing ABCs straight from collections module
+# (which will stop working in 3.8).
+if py33:
+    import collections.abc as collections_abc
+else:
+    import collections as collections_abc
+

--- a/test/sql/test_operators.py
+++ b/test/sql/test_operators.py
@@ -636,7 +636,7 @@ class ExtensionOperatorTest(fixtures.TestBase, testing.AssertsCompiledSQL):
                     return self.op("->")(index)
 
         col = Column('x', MyType())
-        assert not isinstance(col, collections.Iterable)
+        assert not isinstance(col, util.collections_abc.Iterable)
 
     def test_lshift(self):
         class MyType(UserDefinedType):


### PR DESCRIPTION
In Python 3.3, the abstract base classes (Iterable, Mapping, etc.)
were moved from the `collections` module and put in the
`collections.abc` module. They remain in the `collections` module for
backwards compatibility, and will until Python 3.8.

This commit adds a variable (`collections_abc`) to the `util/compat`
module, which will be the `collections` module for Python < 3.3 and
before, or the `collections.abc` module for Python >= 3.3. It also
uses the new variable, getting rid of some deprecation warnings that
were seen when running under Python 3.7.