### PR TITLE
Add `postgresql_psycopg2binary` install extra that installs `psycopg2-binary`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -157,6 +157,7 @@ def run_setup(with_cext):
             'mysql': ['mysqlclient'],
             'pymysql': ['pymysql'],
             'postgresql': ['psycopg2'],
+            'postgresql_psycopg2binary': ['psycopg2-binary'],            
             'postgresql_pg8000': ['pg8000'],
             'postgresql_psycopg2cffi': ['psycopg2cffi'],
             'oracle': ['cx_oracle'],


### PR DESCRIPTION
Closes: https://bitbucket.org/zzzeek/sqlalchemy/issues/4306/create-new-install-extra-for-psycopg2