### PR TITLE
Proposing LIFO for connection pooling

### DIFF
--- a/lib/sqlalchemy/engine/strategies.py
+++ b/lib/sqlalchemy/engine/strategies.py
@@ -123,7 +123,8 @@ class DefaultEngineStrategy(EngineStrategy):
                          'events': 'pool_events',
                          'use_threadlocal': 'pool_threadlocal',
                          'reset_on_return': 'pool_reset_on_return',
-                         'pre_ping': 'pool_pre_ping'}
+                         'pre_ping': 'pool_pre_ping',
+                         'use_lifo': 'pool_use_lifo'}
             for k in util.get_cls_kwargs(poolclass):
                 tk = translate.get(k, k)
                 if tk in kwargs:

--- a/lib/sqlalchemy/pool/impl.py
+++ b/lib/sqlalchemy/pool/impl.py
@@ -177,6 +177,56 @@ class QueuePool(Pool):
         return self._pool.maxsize - self._pool.qsize() + self._overflow
 
 
+class StackPool(QueuePool):
+    """
+    A pool which uses the Stack data structure.
+
+    SQLAlchemy uses Queue data structure as default to provides the connection pool to threads round-robin basis.
+    Which leads to maintain all connections though the server's load isn't that high enough to maintain all connections.
+    """
+    def __init__(self, creator, pool_size=5, max_overflow=10, timeout=30, **kw):
+        r"""
+        Construct a StackPool.
+
+        :param creator: a callable function that returns a DB-API
+          connection object, same as that of :paramref:`.Pool.creator`.
+
+        :param pool_size: The size of the pool to be maintained,
+          defaults to 5. This is the largest number of connections that
+          will be kept persistently in the pool. Note that the pool
+          begins with no connections; once this number of connections
+          is requested, that number of connections will remain.
+          ``pool_size`` can be set to 0 to indicate no size limit; to
+          disable pooling, use a :class:`~sqlalchemy.pool.NullPool`
+          instead.
+
+        :param max_overflow: The maximum overflow size of the
+          pool. When the number of checked-out connections reaches the
+          size set in pool_size, additional connections will be
+          returned up to this limit. When those additional connections
+          are returned to the pool, they are disconnected and
+          discarded. It follows then that the total number of
+          simultaneous connections the pool will allow is pool_size +
+          `max_overflow`, and the total number of "sleeping"
+          connections the pool will allow is pool_size. `max_overflow`
+          can be set to -1 to indicate no overflow limit; no limit
+          will be placed on the total number of concurrent
+          connections. Defaults to 10.
+
+        :param timeout: The number of seconds to wait before giving up
+          on returning a connection. Defaults to 30.
+
+        :param \**kw: Other keyword arguments including
+          :paramref:`.Pool.recycle`, :paramref:`.Pool.echo`,
+          :paramref:`.Pool.reset_on_return` and others are passed to the
+          :class:`.Pool` constructor.
+
+        """
+
+        super(StackPool, self).__init__(creator, pool_size, max_overflow, timeout, **kw)
+        self._pool = sqla_queue.Stack(pool_size)
+
+
 class NullPool(Pool):
 
     """A Pool which does not pool connections.

--- a/lib/sqlalchemy/util/queue.py
+++ b/lib/sqlalchemy/util/queue.py
@@ -44,7 +44,7 @@ class Queue:
 
         If `maxsize` is <= 0, the queue size is infinite.
 
-        If `use_fifo` is False, this Queue acts like Stack (LIFO).
+        If `use_lifo` is True, this Queue acts like a Stack (LIFO).
         """
 
         self._init(maxsize)

--- a/lib/sqlalchemy/util/queue.py
+++ b/lib/sqlalchemy/util/queue.py
@@ -23,7 +23,7 @@ from time import time as _time
 from .compat import threading
 
 
-__all__ = ['Empty', 'Full', 'Queue']
+__all__ = ['Empty', 'Full', 'Queue', 'Stack']
 
 
 class Empty(Exception):
@@ -197,3 +197,10 @@ class Queue:
     # Get an item from the queue
     def _get(self):
         return self.queue.popleft()
+
+
+class Stack(Queue):
+    """Stack data structure for SQLAlchemy. Popping from the right will make default Queue data structure to the Stack.
+    """
+    def _get(self):
+        return self.queue.pop()

--- a/lib/sqlalchemy/util/queue.py
+++ b/lib/sqlalchemy/util/queue.py
@@ -39,10 +39,12 @@ class Full(Exception):
 
 
 class Queue:
-    def __init__(self, maxsize=0):
+    def __init__(self, maxsize=0, use_lifo=False):
         """Initialize a queue object with a given maximum size.
 
         If `maxsize` is <= 0, the queue size is infinite.
+
+        If `use_fifo` is False, this Queue acts like Stack (LIFO).
         """
 
         self._init(maxsize)
@@ -57,6 +59,8 @@ class Queue:
         # Notify not_full whenever an item is removed from the queue;
         # a thread waiting to put is notified then.
         self.not_full = threading.Condition(self.mutex)
+        # If this queue uses LIFO or FIFO
+        self.use_lifo = use_lifo
 
     def qsize(self):
         """Return the approximate size of the queue (not reliable!)."""
@@ -196,11 +200,9 @@ class Queue:
 
     # Get an item from the queue
     def _get(self):
-        return self.queue.popleft()
-
-
-class Stack(Queue):
-    """Stack data structure for SQLAlchemy. Popping from the right will make default Queue data structure to the Stack.
-    """
-    def _get(self):
-        return self.queue.pop()
+        if self.use_lifo:
+            # LIFO
+            return self.queue.pop()
+        else:
+            # FIFO
+            return self.queue.popleft()

--- a/lib/sqlalchemy/util/queue.py
+++ b/lib/sqlalchemy/util/queue.py
@@ -23,7 +23,7 @@ from time import time as _time
 from .compat import threading
 
 
-__all__ = ['Empty', 'Full', 'Queue', 'Stack']
+__all__ = ['Empty', 'Full', 'Queue']
 
 
 class Empty(Exception):

--- a/test/engine/test_pool.py
+++ b/test/engine/test_pool.py
@@ -1988,7 +1988,7 @@ class QueuePoolTest(PoolTestBase):
         connections = [c1, c2, c3]
 
         def creator():
-            return connections.pop()
+            return connections.pop(0)
 
         p = pool.QueuePool(creator, use_lifo=True)
 
@@ -2000,7 +2000,7 @@ class QueuePoolTest(PoolTestBase):
         pc2.close()
         pc3.close()
 
-        for i in range(3):
+        for i in range(5):
             pc1 = p.connect()
             assert pc1.connection is c3
             pc1.close()
@@ -2015,12 +2015,12 @@ class QueuePoolTest(PoolTestBase):
             pc3 = p.connect()
             assert pc3.connection is c2
 
-            pc1 = p.connect()
-            assert pc1.connection is c1
+            pc2 = p.connect()
+            assert pc2.connection is c1
 
-            pc1.close()
             pc2.close()
             pc3.close()
+            pc1.close()
 
 
 class ResetOnReturnTest(PoolTestBase):

--- a/test/engine/test_pool.py
+++ b/test/engine/test_pool.py
@@ -1983,6 +1983,45 @@ class QueuePoolTest(PoolTestBase):
             rec.checkin
         )
 
+    def test_stack(self):
+        c1, c2, c3 = Mock(), Mock(), Mock()
+        connections = [c1, c2, c3]
+
+        def creator():
+            return connections.pop()
+
+        p = pool.QueuePool(creator, use_lifo=True)
+
+        pc1 = p.connect()
+        pc2 = p.connect()
+        pc3 = p.connect()
+
+        pc1.close()
+        pc2.close()
+        pc3.close()
+
+        for i in range(3):
+            pc1 = p.connect()
+            assert pc1.connection is c3
+            pc1.close()
+
+            pc1 = p.connect()
+            assert pc1.connection is c3
+
+            pc2 = p.connect()
+            assert pc2.connection is c2
+            pc2.close()
+
+            pc3 = p.connect()
+            assert pc3.connection is c2
+
+            pc1 = p.connect()
+            assert pc1.connection is c1
+
+            pc1.close()
+            pc2.close()
+            pc3.close()
+
 
 class ResetOnReturnTest(PoolTestBase):
     def _fixture(self, **kw):


### PR DESCRIPTION
### Why
- SQLAlchemy's connection pool is using the Queue data structure to provide the connection pools to threads round-robin basis. Which leads to maintain all connections even though the server's load is not that high enough to maintain all connections.
- Using the Stack data structure could solve this problem as connections that are not working will be disconnected from the database.

### Changes
- Added `StackPool` in `lib/sqlalchemy/pool/impl.py`.
- Added `Stack` in  `lib/sqlalchemy/util/queue.py`.