### PR TITLE
Try working around error at interpreter shutdown

### DIFF
--- a/lib/sqlalchemy/orm/state.py
+++ b/lib/sqlalchemy/orm/state.py
@@ -369,6 +369,11 @@ class InstanceState(interfaces.InspectionAttr):
         Will not work otherwise!
 
         """
+        # This may be true when the Python interpreter is shutting down
+        # We can't do much more since most of python builtins are undefined
+        if dict is None:
+            return
+
         instance_dict = self._instance_dict()
         if instance_dict is not None:
             instance_dict._fast_discard(self)


### PR DESCRIPTION
During interpreter shutdown most builtins objects are not available
anymore, and using them will result in an unhandled exception that will
be printed on stderr.

Try working around this issue by testing that one builtins that may be
used are not None

Example raised (apache mod_wsgi)::

    Exception AttributeError: "'NoneType' object has no attribute 'get'"
    in <bound method InstanceState._cleanup of <sqlalchemy.orm.state.InstanceState
    object at 0x6b5c495d9090>> ignored