### PR TITLE
Fix dependency_for final argument (enables vendoring)

### DIFF
--- a/lib/sqlalchemy/util/langhelpers.py
+++ b/lib/sqlalchemy/util/langhelpers.py
@@ -859,7 +859,7 @@ def dependency_for(modulename):
         # unfortunately importlib doesn't work that great either
         tokens = modulename.split(".")
         mod = compat.import_(
-            ".".join(tokens[0:-1]), globals(), locals(), tokens[-1])
+            ".".join(tokens[0:-1]), globals(), locals(), [tokens[-1]])
         mod = getattr(mod, tokens[-1])
         setattr(mod, obj.__name__, obj)
         return obj


### PR DESCRIPTION
We came across this issue because we have vendoring code that tries to import basically anything in the SQLAlchemy library at boot.

The fourth argument provided to `__import__` (which `import_` feeds in to) is supposed to be a a list of strings, but this code is passing a single string. This was causing the sqlalchemy `import_` function to break the string (for example 'interfaces') into an array of single characters ['i', 'n', ...], which causes the actual `__import__` to not find the module `sqlalchemy.orm.i` (since it's trying to impot `sqlalchemy.orm.i` and `sqlalchemy.orm.n` .. etc)