### PR TITLE
Allow dialects to customize group by clause compilation

### DIFF
--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -968,11 +968,7 @@ class SQLCompiler(Compiled):
              for i, c in enumerate(cs.selects))
         )
 
-        group_by = cs._group_by_clause._compiler_dispatch(
-            self, asfrom=asfrom, **kwargs)
-        if group_by:
-            text += " GROUP BY " + group_by
-
+        text += self.group_by_clause(cs, **dict(asfrom=asfrom, **kwargs))
         text += self.order_by_clause(cs, **kwargs)
         text += (cs._limit_clause is not None
                  or cs._offset_clause is not None) and \
@@ -1929,10 +1925,7 @@ class SQLCompiler(Compiled):
                 text += " \nWHERE " + t
 
         if select._group_by_clause.clauses:
-            group_by = select._group_by_clause._compiler_dispatch(
-                self, **kwargs)
-            if group_by:
-                text += " GROUP BY " + group_by
+            text += self.group_by_clause(select, **kwargs)
 
         if select._having is not None:
             t = select._having._compiler_dispatch(self, **kwargs)
@@ -1987,6 +1980,14 @@ class SQLCompiler(Compiled):
 
         """
         return select._distinct and "DISTINCT " or ""
+
+    def group_by_clause(self, select, **kw):
+        group_by = select._group_by_clause._compiler_dispatch(
+            self, **kw)
+        if group_by:
+            return " GROUP BY " + group_by
+        else:
+            return ""
 
     def order_by_clause(self, select, **kw):
         order_by = select._order_by_clause._compiler_dispatch(self, **kw)

--- a/test/dialect/clickhouse/test_compiler.py
+++ b/test/dialect/clickhouse/test_compiler.py
@@ -1,0 +1,74 @@
+from sqlalchemy.dialects.postgresql.base import PGCompiler, PGDialect
+from sqlalchemy.engine.default import DefaultDialect
+from sqlalchemy.sql import column, compiler, func, table
+from sqlalchemy.sql.elements import ClauseList
+from sqlalchemy.testing import AssertsCompiledSQL, \
+    engines, expect_warnings, fixtures
+from sqlalchemy import exc, Integer, select, String
+
+tbl = table(
+  'nba',
+  column('id', Integer),
+  column('name', String)
+)
+
+
+class ClickHouseCompiler(PGCompiler):
+    def group_by_clause(self, select, **kw):
+        # Usage check and move summaries to end of _group_by_clause
+        summ_names = ('rollup', 'with_rollup', 'with_totals')
+        summ_sql = (
+          lambda x: self.process(x), lambda x: 'WITH ROLLUP',
+          lambda x: 'WITH TOTALS')
+        name_sqls = dict(zip(summ_names, summ_sql))
+
+        summaries = [c for c in select._group_by_clause if c.name in summ_names]
+        select._group_by_clause = ClauseList(
+          *list(set(select._group_by_clause) - set(summaries))
+        )
+        text = " GROUP BY"
+        group_by = super(ClickHouseCompiler, self).group_by_clause(select, **kw)
+        if group_by:
+            text = group_by
+        for name in summ_names:
+            for s in summaries:
+                if s.name == name:
+                    text += ' ' + name_sqls[s.name](s)
+        return text
+
+
+class ClickHouseDialect(PGDialect):
+    name = 'clickhouse'
+    statement_compiler = ClickHouseCompiler
+
+
+class CompileGroupByTest(fixtures.TestBase, AssertsCompiledSQL):
+    __dialect__ = ClickHouseDialect()
+
+    def test_group_by_without_summary(self):
+        stmt = select([tbl.c.id]).group_by(tbl.c.id)
+        self.assert_compile(
+            stmt,
+            "SELECT nba.id FROM nba GROUP BY nba.id"
+        )
+
+    def test_group_by_with_rollup(self):
+        stmt = select([tbl.c.id]).group_by(tbl.c.id, func.with_rollup())
+        self.assert_compile(
+            stmt,
+            "SELECT nba.id FROM nba GROUP BY nba.id WITH ROLLUP"
+        )
+
+    def test_group_by_with_rollup_with_totals(self):
+        stmt = select([tbl.c.id]).group_by(tbl.c.id, func.with_rollup(), func.with_totals())
+        self.assert_compile(
+            stmt,
+            "SELECT nba.id FROM nba GROUP BY nba.id WITH ROLLUP WITH TOTALS"
+        )
+
+    def test_group_by_rollup(self):
+        stmt = select([tbl.c.id]).group_by(func.rollup(tbl.c.id, tbl.c.name))
+        self.assert_compile(
+            stmt,
+            "SELECT nba.id FROM nba GROUP BY ROLLUP(nba.id, nba.name)"
+        )


### PR DESCRIPTION
Should make it easier for standalone elements per [discussion](https://bitbucket.org/zzzeek/sqlalchemy/issues/3429/support-for-group-by-cube-set-rollup).  In particular, would help when trying to add [custom summarizing keywords](https://github.com/yandex/ClickHouse/blob/0ca8e20e66281d6bb600537be91b8546d8ab2ca3/dbms/tests/queries/0_stateless/00701_rollup.sql) for ClickHouse (i.e. `GROUP BY a WITH ROLLUP WITH TOTALS`)