### PR TITLE
Import from collections.abc

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/json.py
+++ b/lib/sqlalchemy/dialects/postgresql/json.py
@@ -7,7 +7,6 @@
 from __future__ import absolute_import
 
 import json
-import collections
 
 from .base import ischema_names, colspecs
 from ... import types as sqltypes
@@ -61,7 +60,7 @@ class JSONPathType(sqltypes.JSON.JSONPathType):
         super_proc = self.string_bind_processor(dialect)
 
         def process(value):
-            assert isinstance(value, collections.Sequence)
+            assert isinstance(value, util.collections_abc.Sequence)
             tokens = [util.text_type(elem)for elem in value]
             value = "{%s}" % (", ".join(tokens))
             if super_proc:
@@ -74,7 +73,7 @@ class JSONPathType(sqltypes.JSON.JSONPathType):
         super_proc = self.string_literal_processor(dialect)
 
         def process(value):
-            assert isinstance(value, collections.Sequence)
+            assert isinstance(value, util.collections_abc.Sequence)
             tokens = [util.text_type(elem)for elem in value]
             value = "{%s}" % (", ".join(tokens))
             if super_proc:

--- a/lib/sqlalchemy/engine/result.py
+++ b/lib/sqlalchemy/engine/result.py
@@ -179,8 +179,7 @@ class RowProxy(BaseRowProxy):
 try:
     # Register RowProxy with Sequence,
     # so sequence protocol is implemented
-    from collections import Sequence
-    Sequence.register(RowProxy)
+    util.collections_abc.Sequence.register(RowProxy)
 except ImportError:
     pass
 

--- a/lib/sqlalchemy/sql/base.py
+++ b/lib/sqlalchemy/sql/base.py
@@ -14,7 +14,6 @@ from .. import util, exc
 import itertools
 from .visitors import ClauseVisitor
 import re
-import collections
 
 PARSE_AUTOCOMMIT = util.symbol('PARSE_AUTOCOMMIT')
 NO_ARG = util.symbol('NO_ARG')
@@ -46,7 +45,7 @@ def _generative(fn, *args, **kw):
     return self
 
 
-class _DialectArgView(collections.MutableMapping):
+class _DialectArgView(util.collections_abc.MutableMapping):
     """A dictionary view of dialect-level arguments in the form
     <dialectname>_<argument_name>.
 
@@ -99,7 +98,7 @@ class _DialectArgView(collections.MutableMapping):
         )
 
 
-class _DialectArgDict(collections.MutableMapping):
+class _DialectArgDict(util.collections_abc.MutableMapping):
     """A dictionary view of dialect-level arguments for a specific
     dialect.
 

--- a/lib/sqlalchemy/sql/sqltypes.py
+++ b/lib/sqlalchemy/sql/sqltypes.py
@@ -2098,7 +2098,7 @@ class JSON(Indexable, TypeEngine):
         @util.dependencies('sqlalchemy.sql.default_comparator')
         def _setup_getitem(self, default_comparator, index):
             if not isinstance(index, util.string_types) and \
-                    isinstance(index, collections.Sequence):
+                    isinstance(index, compat.collections_abc.Sequence):
                 index = default_comparator._check_literal(
                     self.expr, operators.json_path_getitem_op,
                     index, bindparam_type=JSON.JSONPathType

--- a/test/sql/test_resultset.py
+++ b/test/sql/test_resultset.py
@@ -1062,13 +1062,13 @@ class ResultProxyTest(fixtures.TablesTest):
             eq_(len(mock_rowcount.__get__.mock_calls), 2)
 
     def test_rowproxy_is_sequence(self):
-        import collections
+        from sqlalchemy.util import collections_abc
         from sqlalchemy.engine import RowProxy
 
         row = RowProxy(
             object(), ['value'], [None],
             {'key': (None, None, 0), 0: (None, None, 0)})
-        assert isinstance(row, collections.Sequence)
+        assert isinstance(row, collections_abc.Sequence)
 
     @testing.provide_metadata
     def test_rowproxy_getitem_indexes_compiled(self):


### PR DESCRIPTION
This fixes https://bitbucket.org/zzzeek/sqlalchemy/issues/4339/deprecationwarnings-on-python-37. Unfortunately, I was not able to run the tests since my machine had limited resources causing pytest to hang and I didn't have SQLite with JSON support causing some tests to fail. Hope I have done my imports right.

I grepped for import on master with the below regex and made changes filtering out some of the imports from `sqlalchemy.collections`

```
(sqlalchemy-env) karthi@ubuntu-s-1vcpu-1gb-blr1-01:~/sql-dev/sqlalchemy$ rg 'collections\.[A-Z]' | grep py
lib/sqlalchemy/util/langhelpers.py:    kw_args = _collections.OrderedDict()
lib/sqlalchemy/sql/sqltypes.py:                    isinstance(index, collections.Sequence):
lib/sqlalchemy/sql/base.py:class _DialectArgView(collections.MutableMapping):
lib/sqlalchemy/sql/base.py:class _DialectArgDict(collections.MutableMapping):
lib/sqlalchemy/orm/instrumentation.py:        adapter = collections.CollectionAdapter(
lib/sqlalchemy/ext/mutable.py:``collections.MutableMapping``; the part that's important to this example is
lib/sqlalchemy/dialects/postgresql/json.py:            assert isinstance(value, collections.Sequence)
lib/sqlalchemy/dialects/postgresql/json.py:            assert isinstance(value, collections.Sequence)
test/sql/test_resultset.py:        assert isinstance(row, collections.Sequence)
test/orm/test_collection.py:        if isinstance(obj.attr, collections.MappedCollection):
test/orm/test_collection.py:        class MyEasyDict(collections.MappedCollection):
test/orm/test_collection.py:        class MyOrdered(util.OrderedDict, collections.MappedCollection):
test/orm/test_collection.py:                collections.MappedCollection.__init__(self, lambda e: e.a)
test/orm/test_collection.py:        class MyDict(collections.MappedCollection):
test/orm/test_collection.py:        class Ordered(util.OrderedDict, collections.MappedCollection):
test/orm/test_collection.py:                collections.MappedCollection.__init__(self, lambda v: v.a)
test/orm/test_collection.py:        class Ordered2(util.OrderedDict, collections.MappedCollection):
test/orm/test_collection.py:                collections.MappedCollection.__init__(self, keyfunc)
```

```
(sqlalchemy-env) karthi@ubuntu-s-1vcpu-1gb-blr1-01:~/sql-dev/sqlalchemy$ rg 'from collection.*import.*[A-Z]' | grep py
lib/sqlalchemy/engine/result.py:    from collections import Sequence
test/dialect/mysql/test_types.py:from collections import OrderedDict
```

Thanks