### PR TITLE
Add reserved word 'function' for MySQL

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -814,10 +814,10 @@ RESERVED_WORDS = set(
      'generated', 'optimizer_costs', 'stored', 'virtual',  # 5.7
 
      'admin', 'cume_dist', 'empty', 'except', 'first_value', 'grouping',
-     'groups', 'json_table', 'last_value', 'nth_value', 'ntile', 'of',
-     'over', 'percent_rank', 'persist', 'persist_only', 'rank', 'recursive',
-     'role', 'row', 'rows', 'row_number', 'system', 'window', # 8.0
-
+     'function', 'groups', 'json_table', 'last_value', 'nth_value',
+     'ntile', 'of', 'over', 'percent_rank', 'persist', 'persist_only',
+     'rank', 'recursive', 'role', 'row', 'rows', 'row_number', 'system',
+     'window',  # 8.0
      ])
 
 AUTOCOMMIT_RE = re.compile(


### PR DESCRIPTION
Based on https://bitbucket.org/zzzeek/sqlalchemy/issues/4348/table-name-function-not-quoted-in-mysql

['function' became reserved in 8.0.1](https://dev.mysql.com/doc/refman/8.0/en/keywords.html#keywords-8-0-detailed-F)

Changing all those lines to keep within the length limit.