### PR TITLE
Allow single-table inheritance to re-list the primary key of the parent

### DIFF
--- a/lib/sqlalchemy/ext/declarative/base.py
+++ b/lib/sqlalchemy/ext/declarative/base.py
@@ -534,11 +534,6 @@ class _MapperConfig(object):
                     )
                 # add any columns declared here to the inherited table.
                 for c in declared_columns:
-                    if c.primary_key:
-                        raise exc.ArgumentError(
-                            "Can't place primary key columns on an inherited "
-                            "class with no table."
-                        )
                     if c.name in inherited_table.c:
                         if inherited_table.c[c.name] is c:
                             continue
@@ -546,6 +541,11 @@ class _MapperConfig(object):
                             "Column '%s' on class %s conflicts with "
                             "existing column '%s'" %
                             (c, cls, inherited_table.c[c.name])
+                        )
+                    if c.primary_key:
+                        raise exc.ArgumentError(
+                            "Can't place primary key columns on an inherited "
+                            "class with no table."
                         )
                     inherited_table.append_column(c)
                     if inherited_mapped_table is not None and \


### PR DESCRIPTION
This just reorders the checks relevant to mapping additional columns for single-table inheritance.

The behaviour change allows users to resolve column conflicts on primary keys in exactly the same way any other column conflict is resolves, but still disallows defining new columns as primary keys

This fixed a usecase for me where my primary key was a composite primary key defined via `declared_attr.cascading`, and enabled me to modify the `declared_attr` to return the base class key where relevant.