### PR TITLE
I adjusted the copy-and-paste warning wording.

### DIFF
--- a/lib/sqlalchemy/ext/declarative/base.py
+++ b/lib/sqlalchemy/ext/declarative/base.py
@@ -374,7 +374,7 @@ class _MapperConfig(object):
                     isinstance(value[0], (Column, MapperProperty))):
                 util.warn("Ignoring declarative-like tuple value of attribute "
                           "%s: possibly a copy-and-paste error with a comma "
-                          "left at the end of the line?" % k)
+                          "accidentally at the end of the line?" % k)
                 continue
             elif not isinstance(value, (Column, MapperProperty)):
                 # using @declared_attr for some object that


### PR DESCRIPTION
I found the use of the word "left" in this sentence to be slightly
confusing.

  Ignoring declarative-like tuple value of attribute %s: possibly
  a copy-and-paste error with a comma left at the end of the line?

The sentence is entirely correct, using the sense of left as
"remaining", but I initially read it as the comma being at the
left side of the line, that is, the beginning rather than the end.

I suggest changing the word "left" to anything else, or removing it.
The present commit changes it to "accidentally". Other options include
"remaining", "still", or no word.