### PR TITLE
Fix for an error when reusing expanding bindparam

### DIFF
--- a/lib/sqlalchemy/engine/default.py
+++ b/lib/sqlalchemy/engine/default.py
@@ -783,7 +783,7 @@ class DefaultExecutionContext(interfaces.ExecutionContext):
                 positiontup.append(name)
 
         def process_expanding(m):
-            return replacement_expressions.pop(m.group(1))
+            return replacement_expressions[m.group(1)]
 
         self.statement = re.sub(
             r"\[EXPANDING_(\S+)\]",


### PR DESCRIPTION
I stumbled upon error when using same `bindparam` with `expanding=True` multiple times in the same query. Stacktrace looks like this:

```
dao/pg/pg_contact_dao.py:173: in get_contacts_by_ids
    {cids_param.key: contact_ids, company_param.key: company_id})
runtime/lib/python2.7/site-packages/sqlalchemy/engine/base.py:2075: in execute
    return connection.execute(statement, *multiparams, **params)
runtime/lib/python2.7/site-packages/sqlalchemy/engine/base.py:948: in execute
    return meth(self, multiparams, params)
runtime/lib/python2.7/site-packages/sqlalchemy/sql/elements.py:269: in _execute_on_connection
    return connection._execute_clauseelement(self, multiparams, params)
runtime/lib/python2.7/site-packages/sqlalchemy/engine/base.py:1060: in _execute_clauseelement
    compiled_sql, distilled_params
runtime/lib/python2.7/site-packages/sqlalchemy/engine/base.py:1132: in _execute_context
    None, None)
runtime/lib/python2.7/site-packages/sqlalchemy/engine/base.py:1413: in _handle_dbapi_exception
    exc_info
runtime/lib/python2.7/site-packages/sqlalchemy/util/compat.py:265: in raise_from_cause
    reraise(type(exception), exception, tb=exc_tb, cause=cause)
runtime/lib/python2.7/site-packages/sqlalchemy/engine/base.py:1127: in _execute_context
    context = constructor(dialect, self, conn, *args)
runtime/lib/python2.7/site-packages/sqlalchemy/engine/default.py:656: in _init_compiled
    positiontup = self._expand_in_parameters(compiled, processors)
runtime/lib/python2.7/site-packages/sqlalchemy/engine/default.py:786: in _expand_in_parameters
    self.statement
runtime/lib/python2.7/re.py:155: in sub
    return _compile(pattern, flags).sub(repl, string, count)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

m = <_sre.SRE_Match object at 0x10a6b4e40>

    def process_expanding(m):
>       return replacement_expressions.pop(m.group(1))
E       StatementError: (exceptions.KeyError) 'b_contact_ids' [SQL: ................]

m          = <_sre.SRE_Match object at 0x10a6b4e40>
replacement_expressions = {}

runtime/lib/python2.7/site-packages/sqlalchemy/engine/default.py:781: StatementError
```

It seems that the problem lies in `process_expanding`. I replaced `pop` with plain `[]` and everything seems to work as expected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zzzeek/sqlalchemy/489)
<!-- Reviewable:end -->
