### PR TITLE
Removed the leading underscore for visitor_iterator property

### DIFF
--- a/lib/sqlalchemy/orm/query.py
+++ b/lib/sqlalchemy/orm/query.py
@@ -311,7 +311,7 @@ class Query(object):
             orm_only = False
 
         if as_filter and self._filter_aliases:
-            for fa in self._filter_aliases._visitor_iterator:
+            for fa in self._filter_aliases.visitor_iterator:
                 adapters.append(
                     (
                         orm_only, fa.replace

--- a/lib/sqlalchemy/sql/visitors.py
+++ b/lib/sqlalchemy/sql/visitors.py
@@ -115,7 +115,7 @@ class ClauseVisitor(object):
     __traverse_options__ = {}
 
     def traverse_single(self, obj, **kw):
-        for v in self._visitor_iterator:
+        for v in self.visitor_iterator:
             meth = getattr(v, "visit_%s" % obj.__visit_name__, None)
             if meth:
                 return meth(obj, **kw)
@@ -142,7 +142,7 @@ class ClauseVisitor(object):
         return visitors
 
     @property
-    def _visitor_iterator(self):
+    def visitor_iterator(self):
         """iterate through this visitor and each 'chained' visitor."""
 
         v = self
@@ -156,7 +156,7 @@ class ClauseVisitor(object):
         the chained visitor will receive all visit events after this one.
 
         """
-        tail = list(self._visitor_iterator)[-1]
+        tail = list(self.visitor_iterator)[-1]
         tail._next = visitor
         return self
 
@@ -200,7 +200,7 @@ class ReplacingCloningVisitor(CloningVisitor):
         """traverse and visit the given expression structure."""
 
         def replace(elem):
-            for v in self._visitor_iterator:
+            for v in self.visitor_iterator:
                 e = v.replace(elem)
                 if e is not None:
                     return e


### PR DESCRIPTION
A leading underscore usually denotes a private member. Since this
is a property and it is used in Query I removed the leading underscore