### PR TITLE
Omit include of no longer existing files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 # any kind of "*" pulls in __init__.pyc files,
 # so all extensions are explicit.
 
-recursive-include doc *.html *.css *.txt *.js *.jpg *.png *.py Makefile *.rst *.mako *.sty
+recursive-include doc *.html *.css *.txt *.js *.png *.py Makefile *.rst *.sty
 recursive-include examples *.py *.xml
 recursive-include test *.py *.dat
 
@@ -9,5 +9,5 @@ recursive-include test *.py *.dat
 # don't come in if --with-cextensions isn't specified.
 recursive-include lib *.c *.txt
 
-include README* AUTHORS LICENSE distribute_setup.py sa2to3.py ez_setup.py sqla_nose.py CHANGES* tox.ini
+include README* AUTHORS LICENSE sqla_nose.py CHANGES* tox.ini
 prune doc/build/output


### PR DESCRIPTION
When installing `SQLAlchemy==1.2.15` I get the following output:

```
Getting distribution for 'SQLAlchemy==1.2.15'.
warning: no files found matching '*.jpg' under directory 'doc'
warning: no files found matching '*.mako' under directory 'doc'
warning: no files found matching 'distribute_setup.py'
warning: no files found matching 'sa2to3.py'
warning: no files found matching 'ez_setup.py'
```