### PR TITLE
Add public accessor to for `is_single_entity` to Query class

### DIFF
--- a/lib/sqlalchemy/orm/loading.py
+++ b/lib/sqlalchemy/orm/loading.py
@@ -42,11 +42,7 @@ def instances(query, cursor, context):
 
     filtered = query._has_mapper_entities
 
-    single_entity = (
-        not query._only_return_tuples
-        and len(query._entities) == 1
-        and query._entities[0].supports_single_entity
-    )
+    single_entity = query.is_single_entity
 
     if filtered:
         if single_entity:

--- a/lib/sqlalchemy/orm/query.py
+++ b/lib/sqlalchemy/orm/query.py
@@ -648,6 +648,18 @@ class Query(Generative):
         """
         self._only_return_tuples = value
 
+    @property
+    def is_single_entity(self):
+        """Returns True if this query returns a single entity for each instance in its
+        result list, and False if this query returns a tuple of entities for each result.
+
+        """
+        return (
+            not self._only_return_tuples
+            and len(self._entities) == 1
+            and self._entities[0].supports_single_entity
+        )
+
     @_generative
     def enable_eagerloads(self, value):
         """Control whether or not eager joins and subqueries are

--- a/test/orm/test_query.py
+++ b/test/orm/test_query.py
@@ -96,32 +96,38 @@ class MiscTest(QueryTest):
 class OnlyReturnTuplesTest(QueryTest):
     def test_single_entity_false(self):
         User = self.classes.User
-        row = create_session().query(User).only_return_tuples(False).first()
+        query = create_session().query(User).only_return_tuples(False)
+        assert query.is_single_entity is True
+        row = query.first()
         assert isinstance(row, User)
 
     def test_single_entity_true(self):
         User = self.classes.User
-        row = create_session().query(User).only_return_tuples(True).first()
+        query = create_session().query(User).only_return_tuples(True)
+        assert query.is_single_entity is False
+        row = query.first()
         assert isinstance(row, collections_abc.Sequence)
 
     def test_multiple_entity_false(self):
         User = self.classes.User
-        row = (
+        query = (
             create_session()
             .query(User.id, User)
             .only_return_tuples(False)
-            .first()
         )
+        assert query.is_single_entity is False
+        row = query.first()
         assert isinstance(row, collections_abc.Sequence)
 
     def test_multiple_entity_true(self):
         User = self.classes.User
-        row = (
+        query = (
             create_session()
             .query(User.id, User)
             .only_return_tuples(True)
-            .first()
         )
+        assert query.is_single_entity is False
+        row = query.first()
         assert isinstance(row, collections_abc.Sequence)
 
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
This is useful when writing middleware between your application
and sqlalchemy, to inspect what type of results we will be seeing.

As an example,

```
    def issue_query_and_wrap_results(query, Wrapper):
      results = query.all()
      for result in results:
        if q.is_single_entity:
          return Wrapper(result)
        else:
          return tuple(Wrapper(r) for r in result)
```
    
Without this accessor, you need to inspect the return results or private members of the
query and try to guess the intent

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

Fixes: #4934