### PR TITLE
Update dialect for pg8000 version 1.16.0

### DIFF
--- a/test/engine/test_deprecations.py
+++ b/test/engine/test_deprecations.py
@@ -579,10 +579,6 @@ class RawExecuteTest(fixtures.TablesTest):
             Column("user_name", VARCHAR(20)),
         )
 
-    @testing.fails_on(
-        "postgresql+pg8000",
-        "pg8000 still doesn't allow single paren without params",
-    )
     def test_no_params_option(self, connection):
         stmt = (
             "SELECT '%'"

--- a/test/engine/test_execute.py
+++ b/test/engine/test_execute.py
@@ -76,10 +76,6 @@ class ExecuteTest(fixtures.TablesTest):
             Column("user_name", VARCHAR(20)),
         )
 
-    @testing.fails_on(
-        "postgresql+pg8000",
-        "pg8000 still doesn't allow single paren without params",
-    )
     def test_no_params_option(self):
         stmt = (
             "SELECT '%'"

--- a/test/requirements.py
+++ b/test/requirements.py
@@ -971,7 +971,7 @@ class DefaultRequirements(SuiteRequirements):
 
     @property
     def json_array_indexes(self):
-        return self.json_type + fails_if("+pg8000")
+        return self.json_type
 
     @property
     def datetime_literals(self):
@@ -1167,13 +1167,6 @@ class DefaultRequirements(SuiteRequirements):
                     "only four decimal places ",
                 ),
                 (
-                    "postgresql+pg8000",
-                    None,
-                    None,
-                    "postgresql+pg8000 has FP inaccuracy even with "
-                    "only four decimal places ",
-                ),
-                (
                     "postgresql+psycopg2cffi",
                     None,
                     None,
@@ -1227,7 +1220,7 @@ class DefaultRequirements(SuiteRequirements):
 
     @property
     def duplicate_key_raises_integrity_error(self):
-        return fails_on("postgresql+pg8000")
+        return exclusions.open()
 
     def _has_pg_extension(self, name):
         def check(config):


### PR DESCRIPTION
### Description

This proposed change just affects the pg8000 driver and tests. The only changes to the tests are to decorators where pg8000 used to fail but is working now. There are still ~11 tests that fail, but this is an improvement over the ~25 that currently fail. I've just released pg8000 version 1.16.0 and it's a fairly big change. The changes to pg8000 are:

* All data types are now sent as text rather than binary.

* Using adapters, custom types can be plugged in to pg8000.

* Previously, named prepared statements were used for all statements.
Now unnamed prepared statements are used by default, and named prepared
statements can be used explicitly by calling the Connection.prepare()
method, which returns a PreparedStatement object.


### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
- [x] A short code fix

I haven't opened an issue in the tracker because the tests were already failing, hope that's okay.

- [ ] A new feature implementation

**Have a splendid day!**