### PR TITLE
Update decl_base.py

### DIFF
--- a/lib/sqlalchemy/orm/decl_base.py
+++ b/lib/sqlalchemy/orm/decl_base.py
@@ -1132,8 +1132,8 @@ def _del_attribute(cls, key):
                 "Can't un-map individual mapped attributes on a mapped class."
             )
         else:
-            type.__delattr__(cls, key)
             cls.__mapper__._expire_memoizations()
+            type.__delattr__(cls, key)
     else:
         type.__delattr__(cls, key)
 


### PR DESCRIPTION
if key is __mapper__ we get an error.
type.__delattr__(cls, key)
cls.__mapper__._expire_memoizations()
so I propoze to change lines order.

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
