### PR TITLE
Allow alias with flat and name (Fixes: #5262)

### DIFF
--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -1410,11 +1410,17 @@ class Join(roles.DMLTableRole, FromClause):
     def _anonymous_fromclause(self, name=None, flat=False):
         sqlutil = util.preloaded.sql_util
         if flat:
-            if name is not None:
-                raise exc.ArgumentError("Can't send name argument with flat")
+            if isinstance(self.left, (FromGrouping, Join)):
+                left_name = name  # will recurse
+            else:
+                left_name = name and '{}_{}'.format(name, self.left.name)
+            if isinstance(self.right, (FromGrouping, Join)):
+                right_name = name  # will recurse
+            else:
+                right_name = name and '{}_{}'.format(name, self.right.name)
             left_a, right_a = (
-                self.left._anonymous_fromclause(flat=True),
-                self.right._anonymous_fromclause(flat=True),
+                self.left._anonymous_fromclause(name=left_name, flat=True),
+                self.right._anonymous_fromclause(name=right_name, flat=True),
             )
             adapter = sqlutil.ClauseAdapter(left_a).chain(
                 sqlutil.ClauseAdapter(right_a)

--- a/test/sql/test_selectable.py
+++ b/test/sql/test_selectable.py
@@ -1979,6 +1979,14 @@ class JoinAnonymizingTest(fixtures.TestBase, AssertsCompiledSQL):
             "a AS a_1 JOIN b AS b_1 ON a_1.a = b_1.b",
         )
 
+    def test_join_alias_flat_name(self):
+        a = table("a", column("a"))
+        b = table("b", column("b"))
+        self.assert_compile(
+            a.join(b, a.c.a == b.c.b)._anonymous_fromclause(flat=True, name='foo'),
+            "a AS foo_a JOIN b AS foo_b ON foo_a.a = foo_b.b",
+        )
+
     def test_composed_join_alias_flat(self):
         a = table("a", column("a"))
         b = table("b", column("b"))
@@ -1995,6 +2003,24 @@ class JoinAnonymizingTest(fixtures.TestBase, AssertsCompiledSQL):
             "a AS a_1 JOIN b AS b_1 ON a_1.a = b_1.b JOIN "
             "(c AS c_1 JOIN d AS d_1 ON c_1.c = d_1.d) "
             "ON b_1.b = c_1.c",
+        )
+
+    def test_composed_join_alias_flat_name(self):
+        a = table("a", column("a"))
+        b = table("b", column("b"))
+        c = table("c", column("c"))
+        d = table("d", column("d"))
+
+        j1 = a.join(b, a.c.a == b.c.b)
+        j2 = c.join(d, c.c.c == d.c.d)
+
+        # note in 1.4 the flat=True flag now descends into the whole join,
+        # as it should
+        self.assert_compile(
+            j1.join(j2, b.c.b == c.c.c)._anonymous_fromclause(flat=True, name='foo'),
+            "a AS foo_a JOIN b AS foo_b ON foo_a.a = foo_b.b JOIN "
+            "(c AS foo_c JOIN d AS foo_d ON foo_c.c = foo_d.d) "
+            "ON foo_b.b = foo_c.c",
         )
 
     def test_composed_join_alias(self):


### PR DESCRIPTION
See comment on prior issue here:

https://github.com/sqlalchemy/sqlalchemy/issues/5262#issuecomment-615438581

### Description
Allow name _and_ flat arguments to alias for the improved readability a name (prefix) adds to the generated SQL without the performance penalty of the subquery style output flat=False produces. If this is accepted and merged, I'll produce a PR for the rel_2_0 branch.

### Checklist

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.

**Have a nice day!**
