### PR TITLE
Fix use of typing.Literal on Python 3.8 and 3.9

### DIFF
--- a/doc/build/changelog/unreleased_20/11820.rst
+++ b/doc/build/changelog/unreleased_20/11820.rst
@@ -1,0 +1,8 @@
+.. change::
+    :tags: bug, orm, typing
+    :tickets: 11814
+
+    Fixed issue where it was not possible to use ``typing.Literal`` with
+    ``Mapped[]`` on Python 3.8 and 3.9.
+
+

--- a/lib/sqlalchemy/util/typing.py
+++ b/lib/sqlalchemy/util/typing.py
@@ -355,7 +355,9 @@ def is_non_string_iterable(obj: Any) -> TypeGuard[Iterable[Any]]:
 
 
 def is_literal(type_: _AnnotationScanType) -> bool:
-    return get_origin(type_) is Literal
+    # Must use equality rather than identity since typing_extensions.Literal is
+    # different from typing.Literal until Python 3.9.8/3.10.1
+    return get_origin(type_) == Literal
 
 
 def is_newtype(type_: Optional[_AnnotationScanType]) -> TypeGuard[NewType]:


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Fixes #11820

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
